### PR TITLE
added RegExp comparison so you can provide RegExp in post request spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,17 @@ var scope = nock('http://myapp.iriscouch.com')
                 });
 ```
 
-The request body can be a string or a JSON object.
+The request body can be a string, a RegExp, or a JSON object.
+
+```js
+var scope = nock('http://myapp.iriscouch.com')
+                .post('/users', /email=.?@gmail.com/gi)
+                .reply(201, {
+                  ok: true,
+                  id: '123ABC',
+                  rev: '946B7D1C'
+                });
+```
 
 ## Specifying replies
 

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -16,6 +16,11 @@ function matchBody(spec, body) {
 
   //strip line endings from both so that we get a match no matter what OS we are running on
   body = body.replace(/\r?\n|\r/g, '');
+
+  if (spec instanceof RegExp) {
+    return body.match(spec);
+  }
+
   if (typeof spec === "string") {
     spec = spec.replace(/\r?\n|\r/g, '');
   }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -314,6 +314,32 @@ test("post with reply callback, uri, and request body", function(t) {
   req.end();
 });
 
+test("post with regexp as spec", function(t) {
+    var scope = nock('http://www.google.com')
+        .post('/echo', /key=v.?l/g)
+        .reply(200, function(uri, body) {
+            return ['OK', uri, body].join(' ');
+        });
+
+    var req = http.request({
+        host: "www.google.com"
+        , method: 'POST'
+        , path: '/echo'
+        , port: 80
+    }, function(res) {
+        res.on('end', function() {
+            scope.done();
+            t.end();
+        });
+        res.on('data', function(data) {
+            t.equal(data.toString(), 'OK /echo key=val' , 'response should match');
+        });
+    });
+
+    req.write('key=val');
+    req.end();
+});
+
 test("post with chaining on call", function(t) {
   var input = 'key=val';
 


### PR DESCRIPTION
I really need this feature that allows you to give a request spec as a RegExp (actually, only by string)
So you can write cool stuff like:
```javascript
var scope = nock('http://www.google.com')
    .post('/echo', 'key=v.?l')
    .reply(200, function(uri, body) {
        return 'OK !';
    });
```
And be able to match requests like `POST http://www.google.com/path key=val`or `key=vul`, or even `key=vl`if you want. 
If the provided pattern is actually not a valid RegExp, then nock considers it as a basic string.