### PR TITLE
Nock shouldn't crash if encoded data is in string form

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -51,7 +51,11 @@ var getBodyFromChunks = function(chunks, headers) {
   if(common.isContentEncoded(headers)) {
     return _.map(chunks, function(chunk) {
       if(!Buffer.isBuffer(chunk)) {
-        throw new Error('content-encoded responses must all be binary buffers');
+        if (typeof chunk === 'string') {
+          chunk = new Buffer(chunk);
+        } else {
+          throw new Error('content-encoded responses must all be binary buffers');
+        }
       }
 
       return chunk.toString('hex');

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "needle": "^0.7.1",
     "pre-commit": "0.0.9",
     "request": "*",
+    "restler": "3.2.2",
     "restify": "^2.8.1",
     "superagent": "~0.15.7",
     "tap": "*"


### PR DESCRIPTION
We use the restler library, and it returns the chunks of data as strings.  Because of that the record feature was throwing an error.  I don't see a reason why nock can't just convert each chunk to a buffer object, then process.  

I have added a test that breaks without the change to lib/recorder.js