### PR TITLE
Adding "Date" and "Content-Length" headers (hidden behind new methods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,32 @@ var scope = nock('http://www.headdy.com')
   .reply(200, 'The default headers should come too');
 ```
 
+### Including Content-Length Header Automatically
+
+When using `scope.reply()` to set a response body manually, you can have the
+`Content-Length` header calculated automatically.
+
+```js
+var scope = nock('http://www.headdy.com')
+  .replyContentLength()
+  .get('/')
+  .reply(200, { hello: 'world' });
+```
+
+**NOTE:** this does not work with streams or other advanced means of specifying
+the reply body.
+
+### Including Date Header Automatically
+
+You can automatically append a `Date` header to your mock reply:
+
+```js
+var scope = nock('http://www.headdy.com')
+  .replyDate(new Date(2015, 0, 1)) // defaults to now, must use a Date object
+  .get('/')
+  .reply(200, { hello: 'world' });
+```
+
 ## HTTP Verbs
 
 Nock supports any HTTP verb, and it has convenience methods for the GET, POST, PUT, HEAD, DELETE, PATCH and MERGE HTTP verbs.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -30,6 +30,7 @@ function startScope(basePath, options) {
       urlParts = url.parse(basePath),
       port = urlParts.port || ((urlParts.protocol === 'http:') ? 80 : 443),
       persist = false,
+      contentLen = false,
       basePathname = urlParts.pathname.replace(/\/$/, '');
 
   basePath = urlParts.protocol + '//' + urlParts.hostname + ':' + port;
@@ -100,6 +101,9 @@ function startScope(basePath, options) {
             }
             if (!this.headers['content-type']) {
               this.headers['content-type'] = 'application/json';
+            }
+            if (contentLen) {
+              this.headers['content-length'] = body.length;
             }
           } catch(err) {
             throw new Error('Error encoding response body into JSON');
@@ -493,6 +497,11 @@ function startScope(basePath, options) {
     return persist;
   }
 
+  function replyContentLength() {
+    contentLen = true;
+    return this;
+  }
+
 
   scope = {
       get: get
@@ -513,6 +522,7 @@ function startScope(basePath, options) {
     , persist: _persist
     , shouldPersist: shouldPersist
     , pendingMocks: pendingMocks
+    , replyContentLength: replyContentLength
   };
 
   return scope;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -31,6 +31,7 @@ function startScope(basePath, options) {
       port = urlParts.port || ((urlParts.protocol === 'http:') ? 80 : 443),
       persist = false,
       contentLen = false,
+      date = null,
       basePathname = urlParts.pathname.replace(/\/$/, '');
 
   basePath = urlParts.protocol + '//' + urlParts.hostname + ':' + port;
@@ -74,6 +75,11 @@ function startScope(basePath, options) {
       if (scope._defaultReplyHeaders) {
         headers = headers || {};
         headers = mixin(scope._defaultReplyHeaders, headers);
+      }
+
+      if (date) {
+        headers = headers || {};
+        headers['date'] = date.toUTCString();
       }
 
       if (headers !== undefined) {
@@ -502,6 +508,11 @@ function startScope(basePath, options) {
     return this;
   }
 
+  function replyDate(d) {
+    date = d || new Date();
+    return this;
+  }
+
 
   scope = {
       get: get
@@ -523,6 +534,7 @@ function startScope(basePath, options) {
     , shouldPersist: shouldPersist
     , pendingMocks: pendingMocks
     , replyContentLength: replyContentLength
+    , replyDate: replyDate
   };
 
   return scope;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1063,6 +1063,7 @@ test("reply with JSON", function(t) {
 
     res.setEncoding('utf8');
     t.equal(res.statusCode, 200);
+    t.notOk(res.headers['date']);
     t.notOk(res.headers['content-length']);
     t.equal(res.headers['content-type'], 'application/json');
     res.on('end', function() {
@@ -1093,6 +1094,28 @@ test("reply with content-length header", function(t){
     , port: 80
   }, function(res) {
     t.equal(res.headers['content-length'], 17);
+    res.on('end', function() {
+      scope.done();
+      t.end();
+    });
+  });
+});
+
+test("reply with date header", function(t){
+  var date = new Date();
+
+  var scope = nock('http://www.jsonreplier.com')
+    .replyDate(date)
+    .get('/')
+    .reply(200, {hello: "world"});
+
+  var req = http.get({
+    host: "www.jsonreplier.com"
+    , path: '/'
+    , port: 80
+  }, function(res) {
+    console.error(res.headers);
+    t.equal(res.headers['date'], date.toUTCString());
     res.on('end', function() {
       scope.done();
       t.end();

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1063,6 +1063,7 @@ test("reply with JSON", function(t) {
 
     res.setEncoding('utf8');
     t.equal(res.statusCode, 200);
+    t.notOk(res.headers['content-length']);
     t.equal(res.headers['content-type'], 'application/json');
     res.on('end', function() {
       t.ok(dataCalled);
@@ -1078,6 +1079,25 @@ test("reply with JSON", function(t) {
 
   req.end();
 
+});
+
+test("reply with content-length header", function(t){
+  var scope = nock('http://www.jsonreplier.com')
+    .replyContentLength()
+    .get('/')
+    .reply(200, {hello: "world"});
+
+  var req = http.get({
+      host: "www.jsonreplier.com"
+    , path: '/'
+    , port: 80
+  }, function(res) {
+    t.equal(res.headers['content-length'], 17);
+    res.on('end', function() {
+      scope.done();
+      t.end();
+    });
+  });
 });
 
 test("filter path with function", function(t) {


### PR DESCRIPTION
This adds the ability to automatically inject the `Date` and `Content-Length` headers. They are hidden behind new methods, so it does not conflict with current behavior:

## Date

This adds the `Date` header to the reply, formatted via `Date#toUTCString()`

```js
scope.replyDate(); // creates an implicit new Date()
scope.replyDate(new Date(2015, 0, 1)); // uses 01-01-2015 as the date
```

## Content-Length

This is just a flag method (like `scope.persist()`) that allows automatically filling in the `Content-Length` header when `scope.reply(...)` is used to inject JSON data.

```js
scope.replyContentLength()
```

If you think this is worth merging, I can update the documentation to reflect these new methods before it is merged.