### PR TITLE
Fix https+allowunmocked

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -371,7 +371,15 @@ function activate() {
       });
 
       if (! matches && allowUnmocked) {
-        return overriddenRequest(options, callback);
+        if (proto === 'https') {
+          var ClientRequest = http.ClientRequest;
+          http.ClientRequest = originalClientRequest;
+          req = overriddenRequest(options, callback);
+          http.ClientRequest = ClientRequest;
+        } else {
+          req = overriddenRequest(options, callback);
+        }
+        return req;
       }
 
       //  NOTE: Since we already overrode the http.ClientRequest we are in fact constructing

--- a/tests/test_https_allowunmocked.js
+++ b/tests/test_https_allowunmocked.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var test          = require('tap').test;
+var mikealRequest = require('request');
+
+test('allowUnmock for https', function(t) {
+  var nock = require('../');
+  var scope = nock('https://www.google.com/', {allowUnmocked: true})
+  .get('/pathneverhit')
+  .reply(200, {foo: 'bar'});
+
+  var options = {
+    method: 'GET',
+    uri: 'https://www.google.com'
+  };
+
+  mikealRequest(options, function(err, resp, body) {
+    t.notOk(err, 'should be no error');
+    t.true(typeof body !== 'undefined', 'body should not be undefined');
+    t.true(body.length !== 0, 'body should not be empty');
+    t.end();
+    return console.log(resp.statusCode, 'body length: ', body.length);
+  });
+});


### PR DESCRIPTION
When nocking a https server with allowUnmocked enabled, fetching unmocked path could not get any data. 

Please refer to the test case for details.