### PR TITLE
Suppress seperator and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,18 @@ nock.recorder.rec({
 });
 ```
 
+## `use_separator` option
+
+By default, nock will wrap it's output with the separator string `<<<<<<-- cut here -->>>>>>` before and after anything it prints, whether to the console or a custom log function given with the `logging` option.
+
+To disable this, set `use_separator` to false.
+
+```js
+nock.recorder.rec({
+  use_separator: false
+});
+```
+
 ## .removeInterceptor()
 This allows removing a specific interceptor for a url. It's useful when there's a list of common interceptors but one test requires one of them to behave differently.
 

--- a/README.md
+++ b/README.md
@@ -727,6 +727,19 @@ nock.recorder.rec({
 
 Note that even when request headers recording is enabled Nock will never record `user-agent` headers. `user-agent` values change with the version of Node and underlying operating system and are thus useless for matching as all that they can indicate is that the user agent isn't the one that was used to record the tests.
 
+## `logging` option
+
+Nock will print using `console.log` by default (assuming that `dont_print` is `false`).  If a different function is passed into `logging`, nock will send the log string (or object, when using `output_objects`) to that function.  Here's a basic example.
+
+```js
+var appendLogToFile = function(content) {
+  fs.appendFile('record.txt', content);
+}
+nock.recorder.rec({
+  logging: appendLogToFile,
+});
+```
+
 ## .removeInterceptor()
 This allows removing a specific interceptor for a url. It's useful when there's a list of common interceptors but one test requires one of them to behave differently.
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -169,6 +169,10 @@ function record(rec_options) {
   var output_objects = optionsIsObject && rec_options.output_objects;
   var enable_reqheaders_recording = optionsIsObject && rec_options.enable_reqheaders_recording;
   var logging = (optionsIsObject && rec_options.logging) || console.log;
+  var use_separator = true;
+  if (optionsIsObject && _.has(rec_options, 'use_separator')) {
+    use_separator = rec_options.use_separator;
+  }
 
   debug(thisRecordingId, 'restoring overridden requests before new overrides');
   //  To preserve backward compatibility (starting recording wasn't throwing if nock was already active)
@@ -236,7 +240,11 @@ function record(rec_options) {
         outputs.push(out);
 
         if (!dont_print) {
-          logging(SEPARATOR + out + SEPARATOR);
+          if (use_separator) {
+            logging(SEPARATOR + out + SEPARATOR);
+          } else {
+            logging(out);
+          }
         }
       });
 

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -509,6 +509,42 @@ tap.test('doesn\'t record request headers by default', function(t) {
   req.end();
 });
 
+
+tap.test('will call a custom logging function', function(t) {
+  nock.restore();
+  nock.recorder.clear();
+  t.equal(nock.recorder.play().length, 0);
+
+  var record = [];
+  var arrayLog = function(content) {
+    record.push(content);
+  }
+
+  nock.recorder.rec({
+    logging: arrayLog
+  });
+
+  var req = http.request({
+      hostname: 'www.example.com',
+      path: '/',
+      method: 'GET',
+      auth: 'foo:bar'
+    }, function(res) {
+      res.resume();
+      res.once('end', function() {
+        nock.restore();
+
+        t.equal(record.length, 1)
+        var ret = record[0]
+        t.type(ret, 'string');
+        t.end();
+      });
+    }
+  );
+  req.end();
+});
+
+
 tap.test('records request headers except user-agent if enable_reqheaders_recording is set to true', function(t) {
   nock.restore();
   nock.recorder.clear();

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -511,6 +511,7 @@ tap.test('doesn\'t record request headers by default', function(t) {
 
 
 tap.test('will call a custom logging function', function(t) {
+  // This also tests that use_separator is on by default.
   nock.restore();
   nock.recorder.clear();
   t.equal(nock.recorder.play().length, 0);
@@ -537,6 +538,42 @@ tap.test('will call a custom logging function', function(t) {
         t.equal(record.length, 1)
         var ret = record[0]
         t.type(ret, 'string');
+        t.end();
+      });
+    }
+  );
+  req.end();
+});
+
+
+tap.test('use_separator:false is respected', function(t) {
+  nock.restore();
+  nock.recorder.clear();
+  t.equal(nock.recorder.play().length, 0);
+
+  var record = [];
+  var arrayLog = function(content) {
+    record.push(content);
+  }
+
+  nock.recorder.rec({
+    logging: arrayLog,
+    output_objects: true,
+    use_separator: false,
+  });
+
+  var req = http.request({
+      hostname: 'www.example.com',
+      path: '/',
+      method: 'GET',
+      auth: 'foo:bar'
+    }, function(res) {
+      res.resume();
+      res.once('end', function() {
+        nock.restore();
+        t.equal(record.length, 1)
+        var ret = record[0];
+        t.type(ret, 'object'); // this is still an object, because the "cut here" strings have not been appended
         t.end();
       });
     }


### PR DESCRIPTION
Hey Pedro @pgte , I'm Peter :)

I'm trying to do a few things with nock.
* Write nock output to a custom log file
* Using objects
* Without the separators

So I needed to add some code for that!

I added a test and documentation for logging.  (The gitter.im chat had that question come up.)  I also added the `use_separator` option, which defaults to true, but allows you to suppress it.  I remember using nock a year ago and I thought the "cut here" string was distracting.

Let me know what you think!