### PR TITLE
simulate socket timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
     - [Repeat response n times](#repeat-response-n-times)
     - [Delay the response](#delay-the-response)
     - [Delay the connection](#delay-the-connection)
+    - [Socket timeout](#socket-timeout)
     - [Chaining](#chaining)
     - [Scope filtering](#scope-filtering)
     - [Path filtering](#path-filtering)
@@ -348,6 +349,31 @@ nock('http://my.server.com')
   .delayConnection(2000) // 2 seconds
   .reply(200, '<html></html>')
 ```
+
+## Socket timeout
+
+You are able to specify the number of milliseconds that your connection should be idle, to simulate a socket timeout.
+
+```js
+nock('http://my.server.com')
+  .get('/')
+  .socketTimeout(2000) // 2 seconds
+  .reply(200, '<html></html>')
+```
+
+To test a request like the following:
+
+```js
+req = http.request('http://my.server.com', function(res) {
+  ...
+});
+req.setTimeout(1000, function() {
+  req.abort();
+});
+req.end();
+```
+
+NOTE: the timeout will be fired immediately, and will not leave the simulated connection idle for the specified period of time.
 
 ## Chaining
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You are able to specify the number of milliseconds that your connection should b
 ```js
 nock('http://my.server.com')
   .get('/')
-  .socketTimeout(2000) // 2 seconds
+  .socketDelay(2000) // 2 seconds
   .reply(200, '<html></html>')
 ```
 

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -174,6 +174,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
     var err = new Error();
     err.code = 'aborted';
+    req.emit('error', err);
     response.emit('close', err);
   };
 
@@ -484,6 +485,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
         mockNextEmit();
       };
+
+      if (interceptor.socketTimeoutInMs && interceptor.socketTimeoutInMs > 0) {
+        req.socket.checkTimeout(interceptor.socketTimeoutInMs);
+      }
 
       if (interceptor.delayConnectionInMs && interceptor.delayConnectionInMs > 0) {
         setTimeout(respond, interceptor.delayConnectionInMs);

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -499,8 +499,8 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         mockNextEmit();
       };
 
-      if (interceptor.socketTimeoutInMs && interceptor.socketTimeoutInMs > 0) {
-        req.socket._checkTimeout(interceptor.socketTimeoutInMs);
+      if (interceptor.socketDelayInMs && interceptor.socketDelayInMs > 0) {
+        req.socket._checkTimeout(interceptor.socketDelayInMs);
       }
 
       if (interceptor.delayConnectionInMs && interceptor.delayConnectionInMs > 0) {

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -500,7 +500,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       };
 
       if (interceptor.socketTimeoutInMs && interceptor.socketTimeoutInMs > 0) {
-        req.socket.checkTimeout(interceptor.socketTimeoutInMs);
+        req.socket._checkTimeout(interceptor.socketTimeoutInMs);
       }
 
       if (interceptor.delayConnectionInMs && interceptor.delayConnectionInMs > 0) {

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -149,6 +149,9 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       }
       requestBodyBuffers.push(buffer);
     }
+    if (aborted) {
+      emitError(new Error('Request aborted'));
+    }
 
     timers.setImmediate(function() {
       req.emit('drain');
@@ -165,17 +168,22 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       req.emit('finish');
       req.emit('end');
     }
+    if (aborted) {
+      emitError(new Error('Request aborted'));
+    }
   };
 
   req.abort = function() {
+    debug('req.abort');
     aborted = true;
     if (!ended) {
       end();
     }
     var err = new Error();
     err.code = 'aborted';
-    req.emit('error', err);
     response.emit('close', err);
+
+    req.socket.destroy();
   };
 
   // restify listens for a 'socket' event to
@@ -476,7 +484,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           cb(response);
         }
 
-        req.emit('response', response);
+        if (aborted) {
+          emitError(new Error('Request aborted'));
+        }
+        else {
+          req.emit('response', response);
+        }
 
         if (isStream(responseBody)) {
           debug('resuming response stream');

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -358,8 +358,14 @@ function startScope(basePath, options) {
       return this;
     }
 
-    function socketTimeout(ms) {
-      this.socketTimeoutInMs = ms;
+    /**
+     * Make the socket idle for a certain number of ms (simulated).
+     *
+     * @param  {integer} ms - Number of milliseconds to wait
+     * @return {scope} - the current scope for chaining
+     */
+    function socketDelay(ms) {
+      this.socketDelayInMs = ms;
       return this;
     }
 
@@ -382,7 +388,7 @@ function startScope(basePath, options) {
       , thrice: thrice
       , delay: delay
       , delayConnection: delayConnection
-      , socketTimeout: socketTimeout
+      , socketDelay: socketDelay
     };
 
     return interceptor;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -358,6 +358,11 @@ function startScope(basePath, options) {
       return this;
     }
 
+    function socketTimeout(ms) {
+      this.socketTimeoutInMs = ms;
+      return this;
+    }
+
     var interceptor = {
         _key: key
       , counter: 1
@@ -377,6 +382,7 @@ function startScope(basePath, options) {
       , thrice: thrice
       , delay: delay
       , delayConnection: delayConnection
+      , socketTimeout: socketTimeout
     };
 
     return interceptor;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -10,7 +10,21 @@ function Socket() {
   socket.writable = true;
 
   socket.setNoDelay = noop;
-  socket.setTimeout = noop;
+  socket.setTimeout = function(timeout, fn) {
+    this.timeout = timeout;
+    this.timeoutFunction = fn;
+  }
+  socket.checkTimeout = function(delay) {
+    if (this.timeout && delay > this.timeout) {
+      if (this.timeoutFunction) {
+        this.timeoutFunction();
+      }
+      else {
+        this.emit('timeout');
+      }
+    }
+  }
+
   socket.setKeepAlive = noop;
   socket.destroy = noop;
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -15,7 +15,7 @@ function Socket() {
     this.timeout = timeout;
     this.timeoutFunction = fn;
   }
-  socket.checkTimeout = function(delay) {
+  socket._checkTimeout = function(delay) {
     if (this.timeout && delay > this.timeout) {
       debug('socket timeout');
       if (this.timeoutFunction) {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('events').EventEmitter,
+    debug        = require('debug')('nock.socket');
 
 module.exports = Socket;
 
@@ -16,6 +17,7 @@ function Socket() {
   }
   socket.checkTimeout = function(delay) {
     if (this.timeout && delay > this.timeout) {
+      debug('socket timeout');
       if (this.timeoutFunction) {
         this.timeoutFunction();
       }

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3553,6 +3553,64 @@ test('you must setup an interceptor for each request', function(t) {
   });
 });
 
+test('calling socketTimeout will emit a timeout', function (t) {
+    nock('http://www.example.com')
+        .get('/')
+        .socketTimeout(10000)
+        .reply(200, 'OK');
+
+    var req = http.request('http://www.example.com', function (res) {
+        res.setEncoding('utf8');
+
+        var body = '';
+
+        res.on('data', function(chunk) {
+            body += chunk;
+        });
+
+        res.once('end', function() {
+            t.fail('socket did not timeout when idle');
+            t.end();
+        });
+    });
+
+    req.setTimeout(5000, function () {
+        t.ok(true);
+        t.end();
+    });
+
+    req.end();
+});
+
+test('calling socketTimeout not emit a timeout if not idle for long enough', function (t) {
+    nock('http://www.example.com')
+        .get('/')
+        .socketTimeout(10000)
+        .reply(200, 'OK');
+
+    var req = http.request('http://www.example.com', function (res) {
+        res.setEncoding('utf8');
+
+        var body = '';
+
+        res.on('data', function(chunk) {
+            body += chunk;
+        });
+
+        res.once('end', function() {
+            t.equal(body, 'OK');
+            t.end();
+        });
+    });
+
+    req.setTimeout(60000, function () {
+        t.fail('socket timed out unexpectedly');
+        t.end();
+    });
+
+    req.end();
+});
+
 test("teardown", function(t) {
   var leaks = Object.keys(global)
     .splice(globalCount, Number.MAX_VALUE);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3553,10 +3553,10 @@ test('you must setup an interceptor for each request', function(t) {
   });
 });
 
-test('calling socketTimeout will emit a timeout', function (t) {
+test('calling socketDelay will emit a timeout', function (t) {
     nock('http://www.example.com')
         .get('/')
-        .socketTimeout(10000)
+        .socketDelay(10000)
         .reply(200, 'OK');
 
     var req = http.request('http://www.example.com', function (res) {
@@ -3582,10 +3582,10 @@ test('calling socketTimeout will emit a timeout', function (t) {
     req.end();
 });
 
-test('calling socketTimeout not emit a timeout if not idle for long enough', function (t) {
+test('calling socketDelay not emit a timeout if not idle for long enough', function (t) {
     nock('http://www.example.com')
         .get('/')
-        .socketTimeout(10000)
+        .socketDelay(10000)
         .reply(200, 'OK');
 
     var req = http.request('http://www.example.com', function (res) {


### PR DESCRIPTION
By passing in a socket timeout to the nock request, it will emit a timeout event on the request if setTimeout has been called with a lower value. It does not actually wait for the specified period of time.

I've checked that this works with the base http library's request.setTimeout and socket.setTimeout, both with a "once" function and an "on timeout" handler.

I wanted to first check if this approach makes sense, and if so I can flesh it out with tests and documentation.

This is related to #164, though for one specific case.