### PR TITLE
Show path in NetConnectNotAllowedError

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -25,11 +25,11 @@ var RequestOverrider = require('./request_overrider'),
  * http.get('http://zombo.com');
  * // throw NetConnectNotAllowedError
  */
-function NetConnectNotAllowedError(host) {
+function NetConnectNotAllowedError(host, path) {
   Error.call(this);
 
   this.name    = 'NetConnectNotAllowedError';
-  this.message = 'Nock: Not allow net connect for "' + host + '"';
+  this.message = 'Nock: Not allow net connect for "' + host + path + '"';
 
   Error.captureStackTrace(this, this.constructor);
 }
@@ -298,7 +298,7 @@ function overrideClientRequest() {
         originalClientRequest.apply(this, arguments);
       } else {
         timers.setImmediate(function () {
-          var error = new NetConnectNotAllowedError(options.host);
+          var error = new NetConnectNotAllowedError(options.host, options.path);
           this.emit('error', error);
         }.bind(this));
       }
@@ -396,7 +396,7 @@ function activate() {
       if (isOff() || isEnabledForNetConnect(options)) {
         return overriddenRequest(options, callback);
       } else {
-        var error = new NetConnectNotAllowedError(options.host);
+        var error = new NetConnectNotAllowedError(options.host, options.path);
         return new ErroringClientRequest(error);
       }
     }

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -229,7 +229,7 @@ tap.test('nockBack record tests', function (nw) {
       http.get('http://www.amazon.com', function(res) {
         throw "should not request this";
       }).on('error', function(err) {
-        t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
+        t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80/"');
         done();
         t.end();
       });
@@ -285,7 +285,7 @@ tap.test('nockBack lockdown tests', function (nw) {
 
 
     req.on('error', function (err) {
-      t.equal(err.message.trim(), 'Nock: Not allow net connect for "google.com:80"');
+      t.equal(err.message.trim(), 'Nock: Not allow net connect for "google.com:80/"');
       t.end();
     });
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2272,7 +2272,7 @@ test('disabled real HTTP request', function(t) {
   http.get('http://www.amazon.com', function(res) {
     throw "should not request this";
   }).on('error', function(err) {
-    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
+    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80/"');
     t.end();
   });
 
@@ -2315,7 +2315,7 @@ test('enable real HTTP request only for google.com, via string', function(t) {
   http.get('http://www.amazon.com', function(res) {
     throw "should not deliver this request"
   }).on('error', function (err) {
-    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
+    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80/"');
   });
 
   t.end();
@@ -2332,7 +2332,7 @@ test('enable real HTTP request only for google.com, via regexp', function(t) {
   http.get('http://www.amazon.com', function(res) {
     throw "should not request this";
   }).on('error', function (err) {
-    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80"');
+    t.equal(err.message, 'Nock: Not allow net connect for "www.amazon.com:80/"');
     t.end();
   });
 

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -9,7 +9,7 @@ test('disable net connect is default', function (t) {
 
   mikealRequest('https://google.com/', function(err, res) {
     assert(err);
-    assert.equal(err.message, 'Nock: Not allow net connect for "google.com:443"');
+    assert.equal(err.message, 'Nock: Not allow net connect for "google.com:443/"');
     t.end();
   })
 });


### PR DESCRIPTION
Just showing the hostname in the error is not descriptive enough. It's more useful to show the full path, so that the developer can easily determine which request is causing the error.