### PR TITLE
Code Coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: Y6V6FlrJbMSqQ05bwtlVrjvP1x41dHUsj

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .idea
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,3 @@
+check:
+    global:
+        lines: 90

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Nock
 
-[![By](https://img.shields.io/badge/made%20by-yld!-32bbee.svg?style=flat-square)](http://yld.io/contact?source=github-nano)[![Build Status](https://secure.travis-ci.org/pgte/nock.png)](http://travis-ci.org/pgte/nock)[![Chat](https://img.shields.io/badge/help-gitter-eb9348.svg?style=flat-square)](https://gitter.im/pgte/nock)
+[![By](https://img.shields.io/badge/made%20by-yld!-32bbee.svg?style=flat-square)](http://yld.io/contact?source=github-nano)
+[![Build Status](https://secure.travis-ci.org/pgte/nock.png)](http://travis-ci.org/pgte/nock)
+[![Coverage Status](https://coveralls.io/repos/justincy/nock/badge.svg?branch=coverage)](https://coveralls.io/r/justincy/nock?branch=coverage)
+[![Chat](https://img.shields.io/badge/help-gitter-eb9348.svg?style=flat-square)](https://gitter.im/pgte/nock)
 
 Nock is an HTTP mocking and expectations library for Node.js
 

--- a/package.json
+++ b/package.json
@@ -135,13 +135,13 @@
   },
   "scripts": {
     "test": "node tests/test.js",
-    "coverage": "istanbul cover tests/test.js",
+    "coverage": "istanbul cover tests/test.js && istanbul check-coverage",
     "coveralls": "istanbul cover tests/test.js && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "jshint": "jshint lib/*.js"
   },
   "pre-commit": [
     "jshint",
-    "test"
+    "coverage"
   ],
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -121,18 +121,22 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.0.15",
+    "coveralls": "^2.11.2",
     "hyperquest": "^0.3.0",
+    "istanbul": "^0.3.8",
     "jshint": "^2.5.6",
     "needle": "^0.7.1",
     "pre-commit": "0.0.9",
     "request": "2.51.0",
-    "restler": "3.2.2",
     "restify": "^2.8.1",
+    "restler": "3.2.2",
     "superagent": "~0.15.7",
     "tap": "*"
   },
   "scripts": {
-    "test": "node tests/test_common && node tests/test_intercept && node tests/test_aws_dynamo && node tests/test_back && node tests/test_https_allowunmocked && node tests/test_net_connect && node tests/test_nock_off && node tests/test_recorder && node tests/test_redirects && node tests/test_s3 && node tests/test_url_encoding",
+    "test": "node tests/test.js",
+    "coverage": "istanbul cover tests/test.js",
+    "coveralls": "istanbul cover tests/test.js && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "jshint": "jshint lib/*.js"
   },
   "pre-commit": [

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,11 @@
+require('./test_common');
+require('./test_intercept');
+require('./test_redirects');
+require('./test_aws_dynamo');
+require('./test_back');
+require('./test_https_allowunmocked');
+require('./test_net_connect');
+require('./test_s3');
+require('./test_url_encoding');
+require('./test_nock_off');
+require('./test_recorder');

--- a/tests/test_net_connect.js
+++ b/tests/test_net_connect.js
@@ -4,7 +4,7 @@ var mikealRequest = require('request');
 var assert = require('assert');
 
 test('disable net connect is default', function (t) {
-
+  nock.disableNetConnect();
   nock('http://somethingelsecompletelyunrelated.com').get('/').reply(200);
 
   mikealRequest('https://google.com/', function(err, res) {

--- a/tests/test_redirects.js
+++ b/tests/test_redirects.js
@@ -5,7 +5,8 @@ var test    = require('tap').test;
 var mikealRequest = require('request');
 var nock    = require('../');
 
-test("follows refirects", function(t) {
+test("follows redirects", function(t) {
+
   nock('http://redirecter.com')
     .get('/YourAccount')
     .reply(302, undefined, {
@@ -20,7 +21,6 @@ test("follows refirects", function(t) {
     }
 
     assert.equal(res.statusCode, 200);
-
     assert.equal(body, 'Here is the login page');
     t.end();
   });


### PR DESCRIPTION
#237 

I used [istanbul](https://github.com/gotwarlost/istanbul) for coverage.

All tests are run from one file. Because nock functions as a singleton I had to reorder the tests until it worked.

I replaced the test pre-commit with the coverage since it runs all the tests too. It's set to reject commits if coverage is not at least 90% globally. Run `istanbul help config` to see what other options are available.

I integrated with [coveralls.io](https://coveralls.io/) to get the coverage badge. You can see the current coverage from my repo. If you decided to keep coveralls you would just have to setup your own account, add your repo in coveralls, replace the repo token in `.coveralls.yml`, and update the badge url.

