### PR TITLE
Fix #235: Reset file read stream after first request

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -266,7 +266,7 @@ function startScope(basePath, options) {
     }
 
     function discard() {
-      if (persist && this.filePath) {
+      if ((persist || this.counter > 0) && this.filePath) {
         this.body = fs.createReadStream(this.filePath);
         this.body.pause();
       }


### PR DESCRIPTION
Hello everyone,

on our project with experienced the same problem as described in #235.
As the author concludes nock doesn't return data because the fs readstream is already read to the end and cannot be read a second time.
My proposed fix is to create a new fs read stream if the counter set by .times() (or an alias) has not yet reached zero. This fixes the freeze in our test cases.

Best regards,
Benjamin