### PR TITLE
add syntax sugar for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ If `reqheaders` is not specified or if `host` is not part of it, Nock will autom
 
 If no request headers are specified for mocking then Nock will automatically skip matching of request headers. Since `host` header is a special case which may get automatically inserted by Nock, its matching is skipped unless it was *also* specified in the request being mocked.
 
+Basic authentication can be specified as follows:
+
+```js
+var scope = nock('http://www.example.com')
+    .get('/')
+    .basicAuth({
+      user: 'john',
+      pass: 'doe'
+    })
+    .reply(200);
+```
+
 ### Specifying Reply Headers
 
 You can specify the reply headers like this:

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -281,6 +281,15 @@ function startScope(basePath, options) {
       return this;
     }
 
+    function basicAuth(options) {
+      var username = options['user'];
+      var password = options['pass'];
+      var name = 'authorization';
+      var value = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
+      interceptorMatchHeaders.push({ name: name, value: value });
+      return this;
+    }
+
     /**
      * Set number of times will repeat the interceptor
      * @name times
@@ -382,6 +391,7 @@ function startScope(basePath, options) {
       , matchIndependentOfBody: matchIndependentOfBody
       , filteringPath: filteringPath
       , matchHeader: matchHeader
+      , basicAuth: basicAuth
       , times: times
       , once: once
       , twice: twice

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,6 +1,7 @@
 require('./test_common');
 require('./test_intercept');
 require('./test_redirects');
+require('./test_basic_auth');
 require('./test_aws_dynamo');
 require('./test_back');
 require('./test_https_allowunmocked');

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var test = require('tap').test;
+var mikealRequest = require('request');
+var nock = require('../');
+
+test("basic auth", function(t) {
+  nock('http://super-secure.com')
+    .get('/test')
+    .basicAuth({
+      user: 'foo',
+      pass: 'bar'
+    })
+    .reply(200, 'Here is the content');
+
+  t.test('work when it match', function (t) {
+    mikealRequest({
+      url: 'http://super-secure.com/test',
+      auth: {
+        user: 'foo',
+        pass: 'bar'
+      }
+    }, function(err, res, body) {
+      if (err) {
+        throw err;
+      }
+      t.equal(res.statusCode, 200);
+      t.equal(body, 'Here is the content');
+      t.end();
+    });
+  });
+
+  t.test('fail when it doesnt match', function (t) {
+    mikealRequest({
+      url: 'http://super-secure.com/test',
+    }, function(err, res, body) {
+      t.type(err, 'Error')
+      t.end();
+    });
+  });
+
+});


### PR DESCRIPTION
This PR adds some syntax sugar for basic authentication:
```js
nock('http://super-secure.com')
    .get('/test')
    .basicAuth({ user: 'foo', pass: 'bar' })
    .reply(200, 'Here is the content');
```