### PR TITLE
Use http.IncomingMessage for response objects.

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -262,6 +262,15 @@ function record(rec_options) {
       });
 
       var dataChunks = [];
+      var encoding;
+
+      // We need to be aware of changes to the stream's encoding so that we
+      // don't accidentally mangle the data.
+      var setEncoding = res.setEncoding;
+      res.setEncoding = function (newEncoding) {
+        encoding = newEncoding;
+        return setEncoding.apply(this, arguments);
+      };
 
       //  Give the actual client a chance to setup its listeners.
       //  We will use the listener information to figure out
@@ -338,6 +347,9 @@ function record(rec_options) {
 
         var onData = function(data) {
           debug(thisRecordingId, 'new data chunk on', proto);
+          if (encoding) {
+            data = new Buffer(data, encoding);
+          }
           dataChunks.push(data);
         };
         res.on('data', onData);

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -340,10 +340,7 @@ function record(rec_options) {
         //  before us, we need to remove them and setup our own.
         _.each(res.listeners('data'), function(listener) {
           res.removeListener('data', listener);
-        })
-        _.each(res.listeners('readable'), function(listener) {
-          res.removeListener('readable', listener);
-        })
+        });
 
         var onData = function(data) {
           debug(thisRecordingId, 'new data chunk on', proto);

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -4,7 +4,7 @@ var EventEmitter     = require('events').EventEmitter,
     http             = require('http'),
     propagate        = require('propagate'),
     DelayedBody      = require('./delayed_body'),
-    OutgoingMessage  = http.OutgoingMessage,
+    IncomingMessage  = http.IncomingMessage,
     ClientRequest    = http.ClientRequest,
     common           = require('./common'),
     Socket           = require('./socket'),
@@ -85,7 +85,7 @@ function setRequestHeaders(req, options, interceptor) {
 
 function RequestOverrider(req, options, interceptors, remove, cb) {
 
-  var response = new OutgoingMessage(new EventEmitter()),
+  var response = new IncomingMessage(new EventEmitter()),
       requestBodyBuffers = [],
       originalInterceptors = interceptors,
       aborted,
@@ -212,13 +212,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   end = function(cb) {
     debug('ending');
     ended = true;
-    var encoding,
-        requestBody,
+    var requestBody,
         responseBody,
         responseBuffers,
-        interceptor,
-        paused,
-        mockEmits = [];
+        interceptor;
 
     //  When request body is a binary buffer we internally use in its hexadecimal representation.
     var requestBodyBuffer = common.mergeChunks(requestBodyBuffers);
@@ -377,10 +374,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
           debug('response body is a stream');
           responseBody.pause();
           responseBody.on('data', function(d) {
-            response.emit('data', d);
+            response.push(d);
           });
           responseBody.on('end', function() {
-            response.emit('end');
+            response.push(null);
           });
           responseBody.on('error', function(err) {
             response.emit('error', err);
@@ -400,113 +397,11 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
 
       if (aborted) { return; }
 
-      response.setEncoding = function(newEncoding) {
-        encoding = newEncoding;
-      };
-
-      response.pause = function() {
-        debug('pausing mocking');
-        paused = true;
-        if (isStream(responseBody)) {
-          responseBody.pause();
-        }
-      };
-
-      response.resume = function() {
-        debug('resuming mocking');
-        paused = false;
-        if (isStream(responseBody)) {
-          responseBody.resume();
-        }
-        mockNextEmit();
-      };
-
-      var read = false;
-      response.read = function() {
-        debug('reading response body');
-        if (isStream(responseBody) && responseBody.read) {
-          return responseBody.read();
-        } else {
-          if (! read) {
-            read = true;
-            return responseBody;
-          } else {
-            return null;
-          }
-        }
-      };
-
-      //  HACK: Flag our response object as readable so that it can be automatically
-      //    resumed by Node when drain happens. This enables working with some agents
-      //    that behave differently than built-in agent (e.g. needle, superagent).
-      //    The correct way to implement this would be to use IncomingMessage instead
-      //    of OutgoingMessage class to mock responses.
-      response.readable = true;
-
       /// response.client.authorized = true
       /// fixes https://github.com/pgte/nock/issues/158
       response.client = _.extend(response.client || {}, {
         authorized: true
       });
-
-      //  `mockEmits` is an array of emits to be performed during mocking.
-      if (typeof responseBody !== "undefined") {
-        mockEmits.push(function() {
-          if (encoding) {
-            debug('transforming body per its encoding');
-            if (isStream(responseBody)) {
-              responseBody.setEncoding(encoding);
-            } else {
-              responseBody = responseBody.toString(encoding);
-            }
-          }
-          if (! isStream(responseBody)) {
-            debug('emitting response body');
-            response.emit('data', responseBody);
-            response.emit('readable');
-          }
-        });
-      } else {
-        //  We will emit response buffers one by one.
-        _.each(responseBuffers, function(buffer) {
-          mockEmits.push(function() {
-            debug('emitting response buffer');
-            response.emit('data', buffer);
-            response.emit('readable');
-          });
-        });
-      }
-
-      if (!isStream(responseBody)) {
-        mockEmits.push(function() {
-          debug('emitting end');
-          response.emit('end');
-        });
-      }
-
-      function mockNextEmit() {
-        debug('mocking next emit');
-
-        //  We don't use `process.nextTick` because we *want* (very much so!)
-        //  for I/O to happen before the next `emit` since we are precisely mocking I/O.
-        //  Otherwise the writing to output pipe may stall invoking pause()
-        //  without ever calling resume() (the observed was behavior on superagent
-        //  with Node v0.10.26)
-        timers.setImmediate(function() {
-          if (paused || mockEmits.length === 0 || aborted) {
-            debug('mocking paused, aborted or finished');
-            return;
-          }
-
-          var nextMockEmit = mockEmits.shift();
-          nextMockEmit();
-
-          //  Recursively invoke to mock the next emit after the last one was handled.
-          mockNextEmit();
-        });
-      }
-
-      debug('mocking', mockEmits.length, 'emits');
 
       process.nextTick(function() {
         var respond = function() {
@@ -528,8 +423,28 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
             debug('resuming response stream');
             responseBody.resume();
           }
+          else {
+            responseBuffers = responseBuffers || [];
+            if (typeof responseBody !== "undefined") {
+              debug('adding body to buffer list');
+              responseBuffers.push(responseBody);
+            }
 
-          mockNextEmit();
+            // Stream the response chunks one at a time.
+            timers.setImmediate(function emitChunk() {
+              var chunk = responseBuffers.shift();
+
+              if (chunk) {
+                debug('emitting response chunk');
+                response.push(chunk);
+                timers.setImmediate(emitChunk);
+              }
+              else {
+                debug('ending response stream');
+                response.push(null);
+              }
+            });
+          }
         };
 
         if (interceptor.socketDelayInMs && interceptor.socketDelayInMs > 0) {

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -123,12 +123,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     setHeader(req, 'Authorization', 'Basic ' + (new Buffer(options.auth)).toString('base64'));
   }
 
-  // Mock response.connection and request.connection
-  // Fixes: https://github.com/flatiron/nock/issues/74
-  if (! response.connection) {
-    response.connection = new EventEmitter();
-  }
-
   if (! req.connection) {
     req.connection = new EventEmitter();
   }
@@ -355,14 +349,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         {
           response.statusCode = Number(responseBody[0]);
           responseBody = responseBody[1];
-        }
-
-        if (!Buffer.isBuffer(responseBody) && !isStream(responseBody)) {
-          if (typeof responseBody === 'string') {
-            responseBody = new Buffer(responseBody);
-          } else {
-            responseBody = JSON.stringify(responseBody);
-          }
         }
 
         if (interceptor.delayInMs) {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "restler": "3.2.2",
     "rimraf": "^2.3.2",
     "superagent": "~0.15.7",
-    "tap": "*"
+    "tap": "^0.7.1"
   },
   "scripts": {
     "test": "node tests/test.js",

--- a/tests/test_back_2.js
+++ b/tests/test_back_2.js
@@ -34,6 +34,9 @@ test('recording', function(t) {
         t.ok(fixtureContent.status == 302 || fixtureContent.status == 301);
         t.end();
       });
+      // Streams start in 'paused' mode and must be started.
+      // See https://nodejs.org/api/stream.html#stream_class_stream_readable
+      res.resume();
     });
   });
 }).once('end', function() {

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -338,7 +338,8 @@ tap.test('records and replays gzipped nocks correctly', function(t) {
     nock.recorder.clear();
     nock.activate();
 
-    t.equal(nockDefs.length, 3);
+    // Original bit.ly request is redirected to the target page.
+    t.true(nockDefs.length > 1);
     var nocks = nock.define(nockDefs);
 
     debug('make request to mock');
@@ -394,7 +395,8 @@ tap.test('records and replays gzipped nocks correctly when gzip is returned as a
     nock.recorder.clear();
     nock.activate();
 
-    t.equal(nockDefs.length, 3);
+    // Original bit.ly request is redirected to the target page.
+    t.true(nockDefs.length > 1);
     var nocks = nock.define(nockDefs);
 
     debug('make request to mock');
@@ -455,7 +457,8 @@ tap.test('records and replays nocks correctly', function(t) {
     nock.recorder.clear();
     nock.activate();
 
-    t.equal(nockDefs.length, 3);
+    // Original bit.ly request is redirected to the target page.
+    t.true(nockDefs.length > 1);
     var nocks = nock.define(nockDefs);
 
     debug('make request to mock');

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -375,8 +375,17 @@ tap.test('records and replays gzipped nocks correctly when gzip is returned as a
   });
 
   var makeRequest = function(callback) {
-    rest.get('http://bit.ly/1hKHiTe', {'headers':{'Accept-Encoding':'gzip, deflate'}})
-      .on('fail', function(error, response){t.ok(!error);})
+    rest.get('http://bit.ly/1hKHiTe', {'headers':{'Accept-Encoding':'gzip'}})
+      .on('fail', function(data, response){
+        debug('request failed with code ' + response.statusCode);
+        t.ok(false);
+        t.end();
+      })
+      .on('error', function (error, response){
+        debug('request error ' + error.stack);
+        t.ok(false);
+        t.end();
+      })
       .on('success', callback);
   };
 


### PR DESCRIPTION
The [Node API](https://nodejs.org/api/http.html#http_http_incomingmessage) specifies that HTTP responses should be instances of `http.IncomingMessage`. Not following the API specification breaks libraries that depend on this API contract. These changes update Nock's behavior to be compliant with the Node API.

It's worth pointing out that I modified the behavior of a few existing test cases in this change. My understanding is that these changes more accurately reflect Node's actual behavior, but I'm open to feedback if I it seems that I missed something or if I misunderstood the intent of any of the tests.