### PR TITLE
Use functions to generate header values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ var scope = nock('http://www.headdy.com')
    });
 ```
 
+Or you can use a function to generate the headers values. The function will be
+passed the request, response, and body (if available). The body will be either a
+buffer, a stream, or undefined.
+
+```js
+var scope = nock('http://www.headdy.com')
+   .get('/')
+   .reply(200, 'Hello World!', {
+     'X-My-Headers': function (req, res, body) {
+       return body.toString();
+     }
+   });
+```
+
 ### Default Reply Headers
 
 You can also specify default reply headers for all responses like this:
@@ -338,6 +352,19 @@ var scope = nock('http://www.headdy.com')
   .defaultReplyHeaders({
     'X-Powered-By': 'Rails',
     'Content-Type': 'application/json'
+  })
+  .get('/')
+  .reply(200, 'The default headers should come too');
+```
+
+Or you can use a function to generate the default headers values:
+
+```js
+var scope = nock('http://www.headdy.com')
+  .defaultReplyHeaders({
+    'Content-Length': function (req, res, body) {
+      return body.length;
+    }
   })
   .get('/')
   .reply(200, 'The default headers should come too');

--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -1,13 +1,10 @@
 'use strict';
-
-function clone(o) {
-	return JSON.parse(JSON.stringify(o));
-}
+var _ = require("lodash");
 
 function mixin(a, b) {
 	if (! a) { a = {}; }
 	if (! b) {b = {}; }
-	a = clone(a);
+	a = _.cloneDeep(a);
 	for(var prop in b) {
 		a[prop] = b[prop];
 	}

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -396,6 +396,15 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         authorized: true
       });
 
+      // Evaluate functional headers.
+      Object.keys(response.headers).forEach(function (key) {
+        var value = response.headers[key];
+
+        if (typeof value === "function") {
+          response.headers[key] = value(req, response, responseBody);
+        }
+      });
+
       process.nextTick(function() {
         var respond = function() {
           debug('emitting response');


### PR DESCRIPTION
This change provides the ability to generate header values and
default header values by evaluating a function. The function is
passed the request, response, and body (if available). The return
value is used as the header value.

Closes #263.