### PR TITLE
Fix nockBack dryrun mode allows no net access by default

### DIFF
--- a/lib/back.js
+++ b/lib/back.js
@@ -96,6 +96,8 @@ var dryrun = {
     recorder.restore();
     nock.cleanAll();
     nock.activate();
+    //  We have to explicitly enable net connectivity as by default it's off.
+    nock.enableNetConnect();
   },
 
 

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -37,7 +37,7 @@ function NetConnectNotAllowedError(host, path) {
 inherits(NetConnectNotAllowedError, Error);
 
 var allInterceptors = {},
-    allowNetConnect = false;
+    allowNetConnect;
 
 /**
  * Enabled real request.
@@ -54,9 +54,9 @@ var allInterceptors = {},
  * nock.enableNetConnect(/(google|amazon)/);
  */
 function enableNetConnect(matcher) {
-  if (typeof matcher === 'string') {
+  if (_.isString(matcher)) {
     allowNetConnect = new RegExp(matcher);
-  } else if (typeof matcher === 'object' && typeof matcher.test === 'function') {
+  } else if (_.isObject(matcher) && _.isFunction(matcher.test)) {
     allowNetConnect = matcher;
   } else {
     allowNetConnect = /.*/;
@@ -78,7 +78,7 @@ function isEnabledForNetConnect(options) {
  * nock.disableNetConnect();
 */
 function disableNetConnect() {
-  allowNetConnect = false;
+  allowNetConnect = undefined;
 }
 
 function isOn() {

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -99,19 +99,46 @@ tap.test('nockBack wild tests', function (nw) {
 
 
 tap.test('nockBack dryrun tests', function (nw) {
+
+  //  Manually disable net connectivity to confirm that dryrun enables it.
+  nock.disableNetConnect();
+  
   nockBack.fixtures = __dirname + '/fixtures';
   nockBack.setMode('dryrun');
+
+  nw.test('goes to internet even when no nockBacks are running', function(t) {
+    var req = http.request({
+        host: "www.amazon.com"
+      , path: '/'
+      , port: 80
+      }, function(res) {
+
+        t.equal(res.statusCode, 200);
+        t.end();
+
+      });
+
+    req.on('error', function(err) {
+
+      //  This should never happen.
+      t.assert(false);
+      t.end();
+
+    });
+
+    req.end();
+  });
 
   nw.test('normal nocks work', function (t) {
     testNock(t);
   });
-
 
   nw.test('uses recorded fixtures', function (t) {
     nockBackWithFixture(t, true);
   });
 
   nw.test('goes it internet, doesn\'t recorded new fixtures', function (t) {
+
     var dataCalled = false;
 
     var fixture = 'someDryrunFixture.json';


### PR DESCRIPTION
Net connection is incorrectly disabled when adding nock to a project that already has unit tests but no nocks (recorded or manual). So this:

```
var nockBack = require('nock').back;

nockBack.fixtures = './fixtures/nock';
```

immediately breaks already existing tests.