### PR TITLE
Allow use with chai 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   ],
   "main": "./index",
   "dependencies": {
-    "chai": "^1.9.2",
+    "chai": ">=1.9.2 <3.0.0",
     "debug": "^1.0.4",
     "lodash": "2.4.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
The version spec continus to allow chai ^1.9.2