### PR TITLE
Use strict equality for deep comparisons

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var deepEqual = require('assert').deepEqual;
+var deepEqual = require('deep-equal');
 var qs = require('querystring');
 
 module.exports =
@@ -47,11 +47,5 @@ function matchBody(spec, body) {
     return spec.call(this, body);
   }
 
-  try {
-    deepEqual(spec, body);
-    return true;
-  } catch(err) {
-    return false;
-  }
-
+  return deepEqual(spec, body, { strict: true });
 };

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   "dependencies": {
     "chai": "^1.9.2",
     "debug": "^1.0.4",
+    "deep-equal": "^1.0.0",
     "lodash": "2.4.1",
     "mkdirp": "^0.5.0",
     "propagate": "0.3.x"

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -10,6 +10,14 @@ tap.test('matchBody ignores new line characters from strings', function(t) {
   t.end()
 });
 
+tap.test('matchBody uses strict equality for deep comparisons', function(t) {
+  var spec = { number: 1 };
+  var body = '{"number": "1"}';
+  var matched = matchBody(spec, body);
+  t.false(matched);
+  t.end()
+});
+
 tap.test('isBinaryBuffer works', function(t) {
 
   //  Returns false for non-buffers.


### PR DESCRIPTION
Nock currently uses the `deepEqual` function from node's assert module to match request bodies. This checks nested attributes using coercive `==` equality, which means that `{"number": "1"}` matches `{"number": 1}`.

This issue left me with a broken test that went unnoticed for a while. This pull request modifies the `matchBody` function to use [substack's deep-equal module](https://github.com/substack/node-deep-equal) with strict mode on, instead of node's assert. This ensures that all deep comparisons happen using strict `===` equality.