### PR TITLE
Fix for Uncaught TypeError: Cannot read property 'match' of undefined

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -37,7 +37,7 @@ function matchBody(spec, body) {
         var contentType = options.headers['Content-Type'] ||
                           options.headers['content-type'];
 
-        if (contentType.match(/application\/x-www-form-urlencoded/)) {
+        if (contentType && contentType.match(/application\/x-www-form-urlencoded/)) {
           body = qs.parse(body);
         }
       }


### PR DESCRIPTION
If no content type provided with function to match request parameters it will fail with specified error
Try this:
```
let nockRequest = nock('https:/...')
        .replyContentLength()
        .post('/httppost', function(body){
                return true;
        }).reply(401, "");
```