### PR TITLE
Add support for query string matching

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -255,8 +255,45 @@ function startScope(basePath, options) {
         }
       }
       matchKey += path;
-      matches = matchKey === this._key;
-      logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
+
+      // Match query strings when using query()
+      var matchQueries = true;
+      var queryIndex = -1;
+      var queries;
+      if (this.queries && (queryIndex = matchKey.indexOf('?')) !== -1) {
+        queries = matchKey.slice(queryIndex + 1).split('&');
+
+        // Only check for query string matches if this.queries is an object
+        if (_.isObject(this.queries)) {
+          for (var i = 0; i < queries.length; i++) {
+            var query = queries[i].split('=');
+
+            if (query[1] === undefined || this.queries[ query[0] ] === undefined) {
+              matchQueries = false;
+              break;
+            }
+
+            var match = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
+            matchQueries = matchQueries && !!match;
+          }
+        }
+
+        // Remove the query string from the matchKey
+        matchKey = matchKey.substr(0, queryIndex);
+      } else if (this.queries) {
+        // If we expected query strings but didn't get any then this isn't a match
+        matchQueries = false;
+      }
+
+      matches = matchKey === this._key && matchQueries;
+
+      // special logger for query()
+      if (queryIndex !== -1) {
+        logger('matching ' + matchKey + '?' + queries.join('&') + ' to ' + this._key + ' with query(' + JSON.stringify(this.queries) + '): ' + matches);
+      } else {
+        logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
+      }
+
       if (matches) {
         matches = (matchBody.call(options, this._requestBody, body));
         if (!matches) {
@@ -318,6 +355,32 @@ function startScope(basePath, options) {
       var name = 'authorization';
       var value = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
       interceptorMatchHeaders.push({ name: name, value: value });
+      return this;
+    }
+
+    /**
+     * Set query strings for the interceptor
+     * @name query
+     * @param Object Object of query string name,values (accepts regexp values)
+     * @public
+     * @example
+     * // Will match 'http://zombo.com/?q=t'
+     * nock('http://zombo.com').get('/').query({q: 't'});
+     */
+    function query(queries) {
+      this.queries = this.queries || {};
+
+      // Allow all query strings to match this route
+      if (queries === true) {
+        this.queries = queries;
+      }
+
+      for (var query in queries) {
+        if (_.isUndefined(this.queries[query])) {
+          this.queries[query] = queries[query];
+        }
+      }
+
       return this;
     }
 
@@ -425,6 +488,7 @@ function startScope(basePath, options) {
       , filteringPath: filteringPath
       , matchHeader: matchHeader
       , basicAuth: basicAuth
+      , query: query
       , times: times
       , once: once
       , twice: twice

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -273,8 +273,8 @@ function startScope(basePath, options) {
               break;
             }
 
-            var match = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
-            matchQueries = matchQueries && !!match;
+            var isMatch = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
+            matchQueries = matchQueries && !!isMatch;
           }
         }
 
@@ -289,7 +289,8 @@ function startScope(basePath, options) {
 
       // special logger for query()
       if (queryIndex !== -1) {
-        logger('matching ' + matchKey + '?' + queries.join('&') + ' to ' + this._key + ' with query(' + JSON.stringify(this.queries) + '): ' + matches);
+        logger('matching ' + matchKey + '?' + queries.join('&') + ' to ' + this._key +
+               ' with query(' + JSON.stringify(this.queries) + '): ' + matches);
       } else {
         logger('matching ' + matchKey + ' to ' + this._key + ': ' + matches);
       }
@@ -375,9 +376,9 @@ function startScope(basePath, options) {
         this.queries = queries;
       }
 
-      for (var query in queries) {
-        if (_.isUndefined(this.queries[query])) {
-          this.queries[query] = queries[query];
+      for (var q in queries) {
+        if (_.isUndefined(this.queries[q])) {
+          this.queries[q] = queries[q];
         }
       }
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3952,6 +3952,132 @@ test('no content type provided', function(t) {
 
 });
 
+test('query() matches a query string of the same name=value', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({foo:'bar'})
+    .reply(200);
+
+  mikealRequest('http://google.com/?foo=bar', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() matches multiple query strings of the same name=value', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({foo:'bar',baz:'foz'})
+    .reply(200);
+
+  mikealRequest('http://google.com/?foo=bar&baz=foz', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() matches multiple query strings of the same name=value regardless of order', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({foo:'bar',baz:'foz'})
+    .reply(200);
+
+  mikealRequest('http://google.com/?baz=foz&foo=bar', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() matches a query string using regexp', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({foo:/.*/})
+    .reply(200);
+
+  mikealRequest('http://google.com/?foo=bar', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() matches a query string that is url encoded', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({foo:'[1]'})
+    .reply(200);
+
+  mikealRequest('http://google.com/?foo=[1]', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() with "true" will allow all query strings to pass', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query(true)
+    .reply(200);
+
+  mikealRequest('http://google.com/?foo=bar&a=1&b=2', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() will not match when there is no query string in the request', function (t) {
+  var scope = nock('https://d.com')
+    .get('/a')
+    .query({foo:'bar'})
+    .reply(200);
+
+  mikealRequest('https://d.com/a', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET https://d.com/a');
+    t.end();
+  })
+});
+
+test('query() will not match when a query string does not match name=value', function (t) {
+  var scope = nock('https://c.com')
+    .get('/b')
+    .query({foo:'bar'})
+    .reply(200);
+
+  mikealRequest('https://c.com/b?foo=baz', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET https://c.com/b?foo=baz');
+    t.end();
+  })
+});
+
+test('query() will not match when a query string is present that was not registered', function (t) {
+  var scope = nock('https://b.com')
+    .get('/c')
+    .query({foo:'bar'})
+    .reply(200);
+
+  mikealRequest('https://b.com/c?foo=bar&baz=foz', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET https://b.com/c?foo=bar&baz=foz');
+    t.end();
+  })
+});
+
+test('query() will not match when a query string is malformed', function (t) {
+  var scope = nock('https://a.com')
+    .get('/d')
+    .query({foo:'bar'})
+    .reply(200);
+
+  mikealRequest('https://a.com/d?foobar', function(err, res) {
+    t.equal(err.message.trim(), 'Nock: No match for request GET https://a.com/d?foobar');
+    t.end();
+  })
+});
+
 
 test("teardown", function(t) {
   var leaks = Object.keys(global)


### PR DESCRIPTION
My proposal for supporting query string matching, following the feel of the `query()` function of superagent. Should help for #82 and #274

Using the new `query()` function you can match query strings in any order (also accepts regexp query string values)

```js
// will match 'http://google.com/?foo=bar&baz=foz' or 'http://google.com/?baz=foz&foo=bar'
nock('http://google.com')
  .get('/')
  .query({foo:'bar', baz:'foz'})
  .reply(200);
```