### PR TITLE
readme: svg badge for build status, flat style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Nock
 
-[![By](https://img.shields.io/badge/made%20by-yld!-32bbee.svg?style=flat-square)](http://yld.io/contact?source=github-nock)
-[![Build Status](https://secure.travis-ci.org/pgte/nock.png)](http://travis-ci.org/pgte/nock)
+[![By](https://img.shields.io/badge/made%20by-yld!-32bbee.svg?style=flat)](http://yld.io/contact?source=github-nock)
+[![Build Status](https://secure.travis-ci.org/pgte/nock.svg)](http://travis-ci.org/pgte/nock)
 [![Coverage Status](https://coveralls.io/repos/pgte/nock/badge.svg?branch=master)](https://coveralls.io/r/pgte/nock?branch=master)
-[![Chat](https://img.shields.io/badge/help-gitter-eb9348.svg?style=flat-square)](https://gitter.im/pgte/nock)
+[![Chat](https://img.shields.io/badge/help-gitter-eb9348.svg?style=flat)](https://gitter.im/pgte/nock)
 
 Nock is an HTTP mocking and expectations library for Node.js
 


### PR DESCRIPTION
- Use high-res svg badge for Buld Status.
- Use `flat` instead of `flat-square` badge style for consistency with other all other badges.