### PR TITLE
query() accepts various typed values

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -378,7 +378,20 @@ function startScope(basePath, options) {
 
       for (var q in queries) {
         if (_.isUndefined(this.queries[q])) {
-          this.queries[q] = queries[q];
+          var value = queries[q];
+
+          switch (true) {
+          case _.isNumber(value): // fall-though
+          case _.isBoolean(value):
+            value = value.toString();
+            break;
+          case _.isUndefined(value): // fall-though
+          case _.isNull(value):
+            value = '';
+            break;
+          }
+          // everything else, incl. Strings and RegExp values are used 'as-is'
+          this.queries[q] = value;
         }
       }
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -1449,10 +1449,10 @@ test("pause response after data", function(t) {
 
   // Manually simulate multiple 'data' events.
   response.emit("data", "one");
-  process.nextTick(function () {
+  setTimeout(function () {
     response.emit("data", "two");
     response.end();
-  });
+  }, 0);
 });
 
 test("response pipe", function(t) {
@@ -3985,6 +3985,19 @@ test('query() matches multiple query strings of the same name=value regardless o
     .reply(200);
 
   mikealRequest('http://google.com/?baz=foz&foo=bar', function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() matches query values regardless of their type of declaration', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({num:1,bool:true,empty:null,str:'fou'})
+    .reply(200);
+
+  mikealRequest('http://google.com/?num=1&bool=true&empty=&str=fou', function(err, res) {
     if (err) throw err;
     t.equal(res.statusCode, 200);
     t.end();


### PR DESCRIPTION
Hi!

This PR adds a little feature that will make the life of test-writers a tiny bit easier. The `query()` method now calls `toString()` for Number and Boolean values that were passed to it, and converts `undefined` and `null` to empty strings `''`. That way `query()` mimics the behavior of `querystring.stringify()`.
I think it will save some unknown, new to nock developer his precious time, when he is trying to figure out why does the query string in the request and in the nock server don't match, when visually they do.

PS I had to fix a test that didn't pass on my machine.