### PR TITLE
query() encoding fix

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -393,6 +393,9 @@ function startScope(basePath, options) {
             value = encodeURIComponent(value);
             break;
           }
+
+          q = encodeURIComponent(q);
+
           // everything else, incl. Strings and RegExp values are used 'as-is'
           this.queries[q] = value;
         }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -389,6 +389,9 @@ function startScope(basePath, options) {
           case _.isNull(value):
             value = '';
             break;
+          case _.isString(value):
+            value = encodeURIComponent(value);
+            break;
           }
           // everything else, incl. Strings and RegExp values are used 'as-is'
           this.queries[q] = value;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4020,13 +4020,13 @@ test('query() matches a query string using regexp', function (t) {
 test('query() matches a query string that is url encoded', function (t) {
   var scope = nock('http://google.com')
     .get('/')
-    .query({foo:'hello&world'})
+    .query({'foo&bar':'hello&world'})
     .reply(200);
 
   var options = {
     uri: 'http://google.com/',
     qs: {
-      foo: 'hello&world'
+      'foo&bar': 'hello&world'
     }
   };
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4020,10 +4020,17 @@ test('query() matches a query string using regexp', function (t) {
 test('query() matches a query string that is url encoded', function (t) {
   var scope = nock('http://google.com')
     .get('/')
-    .query({foo:'[1]'})
+    .query({foo:'hello&world'})
     .reply(200);
 
-  mikealRequest('http://google.com/?foo=[1]', function(err, res) {
+  var options = {
+    uri: 'http://google.com/',
+    qs: {
+      foo: 'hello&world'
+    }
+  };
+
+  mikealRequest(options, function(err, res) {
     if (err) throw err;
     t.equal(res.statusCode, 200);
     t.end();


### PR DESCRIPTION
`query()` arguments are now properly encoded.

I had to fix the test too as it wasn't actually testing the encoding.