### PR TITLE
update chai semver to support versions < 4.0.0 (FIX #361)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   ],
   "main": "./index",
   "dependencies": {
-    "chai": ">=1.9.2 <3.0.0",
+    "chai": ">=1.9.2 <4.0.0",
     "debug": "^1.0.4",
     "deep-equal": "^1.0.0",
     "lodash": "2.4.1",


### PR DESCRIPTION
Latest version of chai 3.x is 3.2.0. The current semver string in package.json does not allow/match 3.2.0. 

Current:

```
"chai": ">=1.9.2 <3.0.0",
```

Recommened:

```
"chai": ">=1.9.2 <4.0.0",
```