### PR TITLE
doc fix - several .reply calls are made without a status, so there is no body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Nock understands query strings. Instead of placing the entire URL, you can speci
 nock('http://example.com')
   .get('/users')
   .query({name: 'pedro', surname: 'teixeira'})
-  .reply({results: [{id: 'pgte'}]});
+  .reply(200, {results: [{id: 'pgte'}]});
 ```
 
 To mock the entire url regardless of the passed query string:
@@ -161,7 +161,7 @@ To mock the entire url regardless of the passed query string:
 nock('http://example.com')
   .get('/users')
   .query(true)
-  .reply({results: [{id: 'pgte'}]});
+  .reply(200, {results: [{id: 'pgte'}]});
 ```
 
 ## Specifying replies


### PR DESCRIPTION
The body from this is empty because there is no status code:
```
nock('http://example.com')
  .get('/users')
  .query({name: 'pedro', surname: 'teixeira'})
  .reply({results: [{id: 'pgte'}]});
```

```js
nock('http://example.com')
  .get('/users')
  .query({name: 'pedro', surname: 'teixeira'})
  .reply(200, {results: [{id: 'pgte'}]});
```
