### PR TITLE
Fix authentication using username only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ node_js:
   - "0.10"
   - "0.11"
   - "0.12"
+  - 4
 script: "npm run coverage"
+sudo: false
 after_success: "npm run coveralls"

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -133,7 +133,7 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     return getHeader(req, name);
   };
 
-  req.socket = response.socket = Socket();
+  req.socket = response.socket = Socket({ proto: options.proto });
 
   req.write = function(buffer, encoding) {
     debug('write', arguments);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -356,7 +356,7 @@ function startScope(basePath, options) {
 
     function basicAuth(options) {
       var username = options['user'];
-      var password = options['pass'];
+      var password = options['pass'] || '';
       var name = 'authorization';
       var value = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
       interceptorMatchHeaders.push({ name: name, value: value });

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -5,8 +5,14 @@ var EventEmitter = require('events').EventEmitter,
 
 module.exports = Socket;
 
-function Socket() {
+function Socket(options) {
   var socket = new EventEmitter();
+
+  options = options || {};
+
+  if (options.proto === 'https') {
+    socket.authorized = true;
+  }
 
   socket.writable = true;
   socket.readable = true;

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "jshint": "^2.5.6",
     "needle": "^0.7.1",
     "pre-commit": "0.0.9",
-    "request": "2.51.0",
+    "request": "2.61.0",
     "restify": "^2.8.1",
     "restler": "3.2.2",
     "rimraf": "^2.3.2",

--- a/tests/test_basic_auth.js
+++ b/tests/test_basic_auth.js
@@ -1,10 +1,12 @@
 'use strict';
 
-var test = require('tap').test;
-var mikealRequest = require('request');
 var nock = require('../');
+var request = require('request');
+var test = require('tap').test;
 
-test("basic auth", function(t) {
+test('basic auth with username and password', function(t) {
+  t.plan(2);
+
   nock('http://super-secure.com')
     .get('/test')
     .basicAuth({
@@ -13,8 +15,8 @@ test("basic auth", function(t) {
     })
     .reply(200, 'Here is the content');
 
-  t.test('work when it match', function (t) {
-    mikealRequest({
+  t.test('succeeds when it matches', function (tt) {
+    request({
       url: 'http://super-secure.com/test',
       auth: {
         user: 'foo',
@@ -24,19 +26,54 @@ test("basic auth", function(t) {
       if (err) {
         throw err;
       }
-      t.equal(res.statusCode, 200);
-      t.equal(body, 'Here is the content');
-      t.end();
+      tt.equal(res.statusCode, 200);
+      tt.equal(body, 'Here is the content');
+      tt.end();
     });
   });
 
-  t.test('fail when it doesnt match', function (t) {
-    mikealRequest({
+  t.test('fails when it doesnt match', function (tt) {
+    request({
       url: 'http://super-secure.com/test',
     }, function(err, res, body) {
-      t.type(err, 'Error')
-      t.end();
+      tt.type(err, 'Error');
+      tt.end();
+    });
+  });
+});
+
+test('basic auth with username only', function(t) {
+  t.plan(2);
+
+  nock('http://super-secure.com')
+    .get('/test')
+    .basicAuth({
+      user: 'foo'
+    })
+    .reply(200, 'Here is the content');
+
+  t.test('succeeds when it matches', function (tt) {
+    request({
+      url: 'http://super-secure.com/test',
+      auth: {
+        user: 'foo'
+      }
+    }, function(err, res, body) {
+      if (err) {
+        throw err;
+      }
+      tt.equal(res.statusCode, 200);
+      tt.equal(body, 'Here is the content');
+      tt.end();
     });
   });
 
+  t.test('fails when it doesnt match', function (tt) {
+    request({
+      url: 'http://super-secure.com/test',
+    }, function(err, res, body) {
+      tt.type(err, 'Error');
+      tt.end();
+    });
+  });
 });

--- a/tests/test_data.js
+++ b/tests/test_data.js
@@ -1,5 +1,4 @@
 var nock = require('../');
-var assert = require('assert');
 var http = require('http');
 
 var tap = require('tap')
@@ -19,7 +18,7 @@ tap.test('data emits', function(t) {
     });
 
     res.on('end', function() {
-      assert.deepEqual(JSON.parse(body), reqBody);
+      t.same(JSON.parse(body), reqBody);
       t.end();
     });
 

--- a/tests/test_dynamic_mock.js
+++ b/tests/test_dynamic_mock.js
@@ -4,8 +4,6 @@ var test = require('tap').test;
 var nock = require('../.');
 var request = require('request');
 
-nock.disableNetConnect();
-
 test('one function returning the body defines a full mock', function(t) {
   var scope = nock('http://acompleteandfullmock.io')
     .get('/abc')

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3225,7 +3225,7 @@ test('fix #146 - resume() is automatically invoked when the response is drained'
     t.notOk(err);
     t.ok(res);
     t.ok(buffer);
-    t.equal(buffer, replyBuffer);
+    t.same(buffer, replyBuffer);
     t.end();
   });
 });


### PR DESCRIPTION
When using just an username for authentication, the password `undefined` would be used instead of `''`.

Depends on #369 (a rebase is required).