### PR TITLE
Fix query() unpassed param issue

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -269,16 +269,27 @@ function startScope(basePath, options) {
 
         // Only check for query string matches if this.queries is an object
         if (_.isObject(this.queries)) {
-          for (var i = 0; i < queries.length; i++) {
-            var query = queries[i].split('=');
+          // Make sure that you have an equal number of keys. We are
+          // looping through the passed query params and not the expected values
+          // if the user passes fewer query params than expected but all values 
+          // match this will throw a false positive. Testing that the length of the
+          // passed query params is equal to the length of expected keys will prevent
+          // us from doing any value checking BEFORE we know if they have all the proper
+          // params
+          if (Object.keys(this.queries).length !== queries.length) {
+            matchQueries = false;
+          } else {
+            for (var i = 0; i < queries.length; i++) {
+              var query = queries[i].split('=');
 
-            if (query[1] === undefined || this.queries[ query[0] ] === undefined) {
-              matchQueries = false;
-              break;
+              if (query[1] === undefined || this.queries[ query[0] ] === undefined) {
+                matchQueries = false;
+                break;
+              }
+
+              var isMatch = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
+              matchQueries = matchQueries && !!isMatch;
             }
-
-            var isMatch = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
-            matchQueries = matchQueries && !!isMatch;
           }
         }
 

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4099,7 +4099,7 @@ test('query() will not match when a query string is malformed', function (t) {
   })
 });
 
-test('query() will not match when a query string has fewer correct values than passed', function (t) {
+test('query() will not match when a query string has fewer correct values than expected', function (t) {
   var scope = nock('http://google.com')
     .get('/')
     .query({

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4099,6 +4099,24 @@ test('query() will not match when a query string is malformed', function (t) {
   })
 });
 
+test('query() will not match when a query string has fewer correct values than passed', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({
+      num:1,
+      bool:true,
+      empty:null,
+      str:'fou'
+    })
+    .reply(200);
+
+  mikealRequest('http://google.com/?num=1str=fou', function(err, res) {
+    if (err) throw err;
+    t.equal(err.message.trim(), 'Nock: No match for request GET http://google.com/?num=1str=fou');
+    t.end();
+  })
+});
+
 
 test("teardown", function(t) {
   var leaks = Object.keys(global)

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4111,7 +4111,6 @@ test('query() will not match when a query string has fewer correct values than e
     .reply(200);
 
   mikealRequest('http://google.com/?num=1str=fou', function(err, res) {
-    if (err) throw err;
     t.equal(err.message.trim(), 'Nock: No match for request GET http://google.com/?num=1str=fou');
     t.end();
   })


### PR DESCRIPTION
This is a fix for a small bug I found in the `query()` handler.

Currently the `query()` option (if passed an `Object`) loops through all passed values and compares them against a set of expected values. This will throw a false positive if the user passes fewer values than expected but all of them match the expected params.

For example, if setup as follows:
```javascript
var scope = nock('http://google.com')
    .get('/')
    .query({
      num:1,
      str:'fou'
    })
    .reply(200);
```

The following requests will all match:
```
http://google.com?num=1
http://google.com?str=fou
http://google.com?str=fou&num=1
```

By checking that there is an equal number of expected and passed params we can at preempt any unnecessary comparison and catch some false positives. 