### PR TITLE
Specify Regex or Function to check Request Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,25 @@ var scope = nock('http://www.example.com', {
     .reply(200);
 ```
 
+Or you can use a Regular Expression or Function check the header values. The function will be
+passed the header value.
+
+```js
+var scope = nock('http://www.example.com', {
+      reqheaders: {
+        'X-My-Headers': function (headerValue) {
+           if (headerValue) {
+             return true;
+           }
+           return false;
+         },
+         'X-My-Awesome-Header': /Awesome/i
+      }
+    })
+    .get('/')
+    .reply(200);
+```
+
 If `reqheaders` is not specified or if `host` is not part of it, Nock will automatically add `host` value to request header.
 
 If no request headers are specified for mocking then Nock will automatically skip matching of request headers. Since `host` header is a special case which may get automatically inserted by Nock, its matching is skipped unless it was *also* specified in the request being mocked.

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -202,21 +202,28 @@ function startScope(basePath, options) {
           return true;
         }
 
+        var reqHeader = this.reqheaders[key];
+        var header = options.headers[key];
+
         //  We skip 'host' header comparison unless it's available in both mock and actual request.
         //  This because 'host' may get inserted by Nock itself and then get recorder.
         //  NOTE: We use lower-case header field names throughout Nock.
         if (key === 'host' &&
-          (_.isUndefined(options.headers[key]) ||
-           _.isUndefined(this.reqheaders[key])))
+          (_.isUndefined(header) ||
+           _.isUndefined(reqHeader)))
         {
           return true;
         }
 
-        if (options.headers[key] === this.reqheaders[key]) {
-          return true;
+        if (reqHeader && header) {
+          if (_.isFunction(reqHeader)) {
+            return reqHeader(header);
+          } else if (matchStringOrRegexp(header, reqHeader)) {
+            return true;
+          }
         }
 
-        debug('request header field doesn\'t match:', key, options.headers[key], this.reqheaders[key]);
+        debug('request header field doesn\'t match:', key, header, reqHeader);
         return false;
       }
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,11 @@
       "name": "Rui Marinho",
       "url": "https://github.com/ruimarinho",
       "email": "ruipmarinho@gmail.com"
+    },
+    {
+      "name": "David Pate",
+      "url": "https://github.com/DavidTPate",
+      "email": "davidtpate@gmail.com"
     }
   ],
   "repository": {


### PR DESCRIPTION
This PR adds the ability to specify request headers which should either match a Regular Expression or satisfy a function. It also adds positive & negative tests around the functionality.