### PR TITLE
Allow filtering nock back recording before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,7 @@ var before = function(scope) {
 }
 
 // recording of the fixture
-nockBack('zomboFixture.json', function(nockDone) { 
+nockBack('zomboFixture.json', function(nockDone) {
   request.get('http://zombo.com', function(err, res, body) {
     nockDone();
 
@@ -1038,7 +1038,7 @@ nockBack('zomboFixture.json', function(nockDone) {
 
       this.assertScopesFinished(); //throws an exception if all nocks in fixture were not satisfied
       http.get('http://zombo.com/').end(); // throws exception because someFixture.json only had one call
-      
+
       nockDone(); //never gets here
     });
   });
@@ -1051,6 +1051,7 @@ As an optional second parameter you can pass the following options
 
 - `before`: a preprocessing function, gets called before nock.define
 - `after`: a postprocessing function, gets called after nock.define
+- `afterRecord`: a postprocessing function, gets called after recording. Is passed the array of scopes recorded and should return the array scopes to save to the fixture
 
 
 ### Modes

--- a/lib/back.js
+++ b/lib/back.js
@@ -27,6 +27,9 @@ var _mode = null;
  *
  * @param {function} before       - a preprocessing function, gets called before nock.define
  * @param {function} after        - a postprocessing function, gets called after nock.define
+ * @param {function} afterRecord  - a postprocessing function, gets called after recording. Is passed the array
+ *                                  of scopes recorded and should return the array scopes to save to the fixture
+
  *
  */
 function Back (fixtureName, options, nockedFn) {
@@ -150,7 +153,13 @@ var record = {
 
   finish: function (fixture, options, context) {
     if( context.isRecording ) {
-      var outputs = JSON.stringify(recorder.outputs(), null, 4);
+      var outputs = recorder.outputs();
+
+      if( typeof options.afterRecord === 'function' ) {
+        outputs = options.afterRecord(outputs);
+      }
+
+      outputs = JSON.stringify(outputs, null, 4);
       debug('recorder outputs:', outputs);
 
       mkdirp.sync(path.dirname(fixture));

--- a/tests/test_back.js
+++ b/tests/test_back.js
@@ -281,6 +281,41 @@ tap.test('nockBack record tests', function (nw) {
 
   });
 
+
+  nw.test('it can filter after recording', function (t) {
+    nockBack.fixtures = __dirname + '/fixtures';
+
+    var options = {
+      host: 'www.google.com', method: 'GET', path: '/', port: 80
+    };
+
+    var fixture = 'filteredFixture.json';
+    var fixtureLoc = nockBack.fixtures + '/' + fixture;
+
+    t.false(exists(fixtureLoc));
+
+    var afterRecord = function(scopes) {
+       // You would do some filtering here, but for this test we'll just return an empty array
+      return [];
+    }
+
+    nockBack(fixture, {afterRecord: afterRecord}, function (done) {
+      http.request(options).end();
+      done();
+
+      t.true(exists(fixtureLoc));
+
+      nockBack(fixture, function (done) {
+        t.true(this.scopes.length == 0);
+        done();
+
+        fs.unlinkSync(fixtureLoc);
+        t.end();
+      });
+    });
+
+  });
+
   nw.end();
 })
 .on('end', function () {


### PR DESCRIPTION
An `afterRecord` option can be passed in which will be called with the array of scopes as a parameter. The function can then filter these as it wishes and return the array of scopes that will be saved to the
fixture.

This fixes #300.

This is my first time in this codebase so please suggest anything :+1: 