### PR TITLE
Add `isDone()` to global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,21 @@ setTimeout(function() {
 
 ## .isDone()
 
-You can also call `isDone()`, which will return a boolean saying if all the expectations are met or not (instead of throwing an exception);
+You can call `isDone()` on a single expectation to determine if the expectation was met:
+
+```js
+var scope = nock('http://google.com')
+  .get('/')
+  .reply(200);
+
+scope.isDone(); // will return false
+```
+
+It is also available in the global scope, which will determine if all expectations have been met:
+
+```js
+nock.isDone();
+```
 
 ## .cleanAll()
 

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -338,6 +338,14 @@ function isActive() {
 
 }
 
+function isDone() {
+  return _.every(allInterceptors, function(interceptors) {
+    return _.every(interceptors, function(interceptor) {
+      return interceptor.__nock_scope.isDone();
+    });
+  });
+}
+
 function activate() {
 
   if(originalClientRequest) {
@@ -414,6 +422,7 @@ module.exports.removeInterceptor = removeInterceptor;
 module.exports.isOn = isOn;
 module.exports.activate = activate;
 module.exports.isActive = isActive;
+module.exports.isDone = isDone;
 module.exports.enableNetConnect = enableNetConnect;
 module.exports.disableNetConnect = disableNetConnect;
 module.exports.overrideClientRequest = overrideClientRequest;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -820,6 +820,7 @@ module.exports = startScope;
 module.exports.cleanAll = cleanAll;
 module.exports.activate = globalIntercept.activate;
 module.exports.isActive = globalIntercept.isActive;
+module.exports.isDone = globalIntercept.isDone;
 module.exports.removeInterceptor = globalIntercept.removeInterceptor;
 module.exports.disableNetConnect = globalIntercept.disableNetConnect;
 module.exports.enableNetConnect = globalIntercept.enableNetConnect;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2125,6 +2125,20 @@ test('clean all works', function(t) {
 
 });
 
+test('is done works', function(t) {
+  var scope = nock('http://amazon.com')
+    .get('/nonexistent')
+    .reply(200);
+
+  t.ok(!scope.isDone());
+
+  var req = http.get({host: 'amazon.com', path: '/nonexistent'}, function(res) {
+    t.assert(res.statusCode === 200, "should mock before cleanup");
+    t.ok(nock.isDone());
+    t.end();
+  });
+});
+
 test('username and password works', function(t) {
   var scope = nock('http://passwordyy.com')
     .get('/')


### PR DESCRIPTION
This PR exposes the `isDone()` function to the global scope. It allows users to determine if all expectations have been met.

Note that I also corrected the _README_ which previously implied that this behaviour was already possible.