### PR TITLE
Improve code coverage for `isDone` method

### DIFF
--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2130,7 +2130,7 @@ test('is done works', function(t) {
     .get('/nonexistent')
     .reply(200);
 
-  t.ok(!scope.isDone());
+  t.ok(!nock.isDone());
 
   var req = http.get({host: 'amazon.com', path: '/nonexistent'}, function(res) {
     t.assert(res.statusCode === 200, "should mock before cleanup");


### PR DESCRIPTION
The previous PR lowered the code coverage a bit because the `isDone()` function wasn't being tested when an expectation was not yet met.

Refs #388