### PR TITLE
Add `pendingMocks()` to global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,12 @@ if (!scope.isDone()) {
 }
 ```
 
+It is also available in the global scope:
+
+```js
+console.error('pending mocks: %j', nock.pendingMocks());
+```
+
 # Logging
 
 Nock can log matches if you pass in a log function like this:

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -349,6 +349,16 @@ function isDone() {
   });
 }
 
+function pendingMocks() {
+  return _.reduce(allInterceptors, function(result, interceptors) {
+    for (var interceptor in interceptors) {
+      result = result.concat(interceptors[interceptor].__nock_scope.pendingMocks());
+    }
+
+    return result;
+  }, []);
+}
+
 function activate() {
 
   if(originalClientRequest) {
@@ -426,6 +436,7 @@ module.exports.isOn = isOn;
 module.exports.activate = activate;
 module.exports.isActive = isActive;
 module.exports.isDone = isDone;
+module.exports.pendingMocks = pendingMocks;
 module.exports.enableNetConnect = enableNetConnect;
 module.exports.disableNetConnect = disableNetConnect;
 module.exports.overrideClientRequest = overrideClientRequest;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -822,6 +822,7 @@ module.exports.cleanAll = cleanAll;
 module.exports.activate = globalIntercept.activate;
 module.exports.isActive = globalIntercept.isActive;
 module.exports.isDone = globalIntercept.isDone;
+module.exports.pendingMocks = globalIntercept.pendingMocks;
 module.exports.removeInterceptor = globalIntercept.removeInterceptor;
 module.exports.disableNetConnect = globalIntercept.disableNetConnect;
 module.exports.enableNetConnect = globalIntercept.enableNetConnect;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2139,6 +2139,20 @@ test('is done works', function(t) {
   });
 });
 
+test('pending mocks works', function(t) {
+  var scope = nock('http://amazon.com')
+    .get('/nonexistent')
+    .reply(200);
+
+  t.deepEqual(nock.pendingMocks(), ['GET http://amazon.com:80/nonexistent']);
+
+  var req = http.get({host: 'amazon.com', path: '/nonexistent'}, function(res) {
+    t.assert(res.statusCode === 200, "should mock before cleanup");
+    t.deepEqual(nock.pendingMocks(), []);
+    t.end();
+  });
+});
+
 test('username and password works', function(t) {
   var scope = nock('http://passwordyy.com')
     .get('/')


### PR DESCRIPTION
This PR is similar to #388 and exposes the pendingMocks() function to the global scope. It allows users to determine which expectations have not been met.