### PR TITLE
New option 'encodedQueryParams'; fixes #413.

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -124,7 +124,9 @@ function generateRequestAndResponse(req, bodyChunks, options, res, dataChunks) {
   var ret = [];
   ret.push('\nnock(\'');
   ret.push(getScope(options));
-  ret.push('\')\n');
+  ret.push('\', ');
+  ret.push(JSON.stringify({ encodedQueryParams: true }));
+  ret.push(')\n');
   ret.push('  .');
   ret.push(getMethod(options).toLowerCase());
   ret.push('(\'');

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -423,11 +423,11 @@ function startScope(basePath, options) {
             value = '';
             break;
           case _.isString(value):
-            value = encodeURIComponent(value);
+            if (!scopeOptions.encodedQueryParams) value = encodeURIComponent(value);
             break;
           }
 
-          q = encodeURIComponent(q);
+          if (!scopeOptions.encodedQueryParams) q = encodeURIComponent(q);
 
           // everything else, incl. Strings and RegExp values are used 'as-is'
           this.queries[q] = value;

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -4169,7 +4169,7 @@ test('query() matches a query string using regexp', function (t) {
   })
 });
 
-test('query() matches a query string that is url encoded', function (t) {
+test('query() matches a query string that contains special RFC3986 characters', function (t) {
   var scope = nock('http://google.com')
     .get('/')
     .query({'foo&bar':'hello&world'})
@@ -4183,6 +4183,31 @@ test('query() matches a query string that is url encoded', function (t) {
   };
 
   mikealRequest(options, function(err, res) {
+    if (err) throw err;
+    t.equal(res.statusCode, 200);
+    t.end();
+  })
+});
+
+test('query() expects unencoded query params', function (t) {
+  var scope = nock('http://google.com')
+    .get('/')
+    .query({'foo':'hello%20world'})
+    .reply(200);
+
+  mikealRequest('http://google.com?foo=hello%20world', function(err, res) {
+    t.similar(err.toString(), /Error: Nock: No match for request/);
+    t.end();
+  });
+});
+
+test('query() matches a query string with pre-encoded values', function (t) {
+  var scope = nock('http://google.com', { encodedQueryParams: true })
+    .get('/')
+    .query({'foo':'hello%20world'})
+    .reply(200);
+
+  mikealRequest('http://google.com?foo=hello%20world', function(err, res) {
     if (err) throw err;
     t.equal(res.statusCode, 200);
     t.end();

--- a/tests/test_recorder.js
+++ b/tests/test_recorder.js
@@ -54,7 +54,7 @@ tap.test('records', function(t) {
       ret = nock.recorder.play();
       t.equal(ret.length, 1);
       t.type(ret[0], 'string');
-      t.equal(ret[0].indexOf("\nnock('http://google.com:80')\n  .post('/', \"ABCDEF\")\n  .reply("), 0);
+      t.equal(ret[0].indexOf("\nnock('http://google.com:80', {\"encodedQueryParams\":true})\n  .post('/', \"ABCDEF\")\n  .reply("), 0);
       t.end();
     });
   });
@@ -227,7 +227,7 @@ tap.test('when request body is json, it goes unstringified', function(t) {
       var ret = nock.recorder.play();
       t.ok(ret.length >= 1);
       ret = ret[1] || ret[0];
-      t.equal(ret.indexOf("\nnock('http://www.google.com:80')\n  .post('/', {\"a\":1,\"b\":true})\n  .reply("), 0);
+      t.equal(ret.indexOf("\nnock('http://www.google.com:80', {\"encodedQueryParams\":true})\n  .post('/', {\"a\":1,\"b\":true})\n  .reply("), 0);
       t.end();
     });
   });
@@ -810,7 +810,7 @@ tap.test('outputs query string parameters using query()', function(t) {
     var ret = nock.recorder.play();
     t.equal(ret.length, 1);
     t.type(ret[0], 'string');
-    var match = "\nnock('https://example.com:443')\n  .get('/')\n  .query({\"param1\":\"1\",\"param2\":\"2\"})\n  .reply(";
+    var match = "\nnock('https://example.com:443', {\"encodedQueryParams\":true})\n  .get('/')\n  .query({\"param1\":\"1\",\"param2\":\"2\"})\n  .reply(";
     t.equal(ret[0].substring(0, match.length), match);
     t.end();
   });
@@ -835,7 +835,7 @@ tap.test('removes query params from from that path and puts them in query()', fu
       ret = nock.recorder.play();
       t.equal(ret.length, 1);
       t.type(ret[0], 'string');
-      t.equal(ret[0].indexOf("\nnock('http://google.com:80')\n  .post('/', \"ABCDEF\")\n  .query({\"param1\":\"1\",\"param2\":\"2\"})\n  .reply("), 0);
+      t.equal(ret[0].indexOf("\nnock('http://google.com:80', {\"encodedQueryParams\":true})\n  .post('/', \"ABCDEF\")\n  .query({\"param1\":\"1\",\"param2\":\"2\"})\n  .reply("), 0);
       t.end();
     });
   });


### PR DESCRIPTION
When enabled, prevents calling of `encodeURIComponent` on query param keys and values.
Additionally, this option is automatically set for scopes generated by the record feature, which is correct because query params are already encoded by the time they are added to these scopes.