### PR TITLE
The underscore wrapped version reads better, only it doesn't work.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -198,7 +198,7 @@ var headersFieldNamesToLowerCase = function(headers) {
   //  For each key in the headers, delete its value and reinsert it with lower-case key.
   //  Keys represent headers field names.
   var lowerCaseHeaders = {};
-  _(headers).keys().each(function(fieldName) {
+  _.each(_.keys(headers), function(fieldName) {
     var lowerCaseFieldName = fieldName.toLowerCase();
     if(!_.isUndefined(lowerCaseHeaders[lowerCaseFieldName])) {
       throw new Error('Failed to convert header keys to lower case due to field name conflict: ' + lowerCaseFieldName);


### PR DESCRIPTION
Ran across this issue when trying to specify content-length header on a .reply().  The call to headersFieldNamesToLowerCase() always returns {} for headers.

Sorry for the lack of tests, it's after 6pm and trying to finish up a production issue.