### PR TITLE
Fix matchBody for multipart requests

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -37,7 +37,7 @@ function matchBody(spec, body) {
         var contentType = options.headers['Content-Type'] ||
                           options.headers['content-type'];
 
-        if (contentType && contentType.match(/application\/x-www-form-urlencoded/)) {
+        if (contentType && contentType.toString().match(/application\/x-www-form-urlencoded/)) {
           body = qs.parse(body);
         }
       }

--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -14,8 +14,16 @@ function matchBody(spec, body) {
     body = body.toString();
   }
 
+  var contentType = options.headers && (options.headers['Content-Type'] ||
+                                        options.headers['content-type']);
+
+  var isMultipart = contentType && contentType.toString().match(/multipart/);
+
   //strip line endings from both so that we get a match no matter what OS we are running on
-  body = body.replace(/\r?\n|\r/g, '');
+  //if Content-Type does not contains 'multipart'
+  if (!isMultipart) {
+    body = body.replace(/\r?\n|\r/g, '');
+  }
 
   if (spec instanceof RegExp) {
     return body.match(spec);
@@ -31,16 +39,11 @@ function matchBody(spec, body) {
     try { json = JSON.parse(body);} catch(err) {}
     if (json !== undefined) {
       body = json;
-    }
-    else
-      if (options.headers) {
-        var contentType = options.headers['Content-Type'] ||
-                          options.headers['content-type'];
-
-        if (contentType && contentType.toString().match(/application\/x-www-form-urlencoded/)) {
-          body = qs.parse(body);
-        }
+    } else {
+      if (contentType && contentType.toString().match(/application\/x-www-form-urlencoded/)) {
+        body = qs.parse(body);
       }
+    }
   }
 
   if (typeof spec === "function") {

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -12,6 +12,16 @@ tap.test('matchBody ignores new line characters from strings', function(t) {
   t.end()
 });
 
+tap.test('matchBody should not throw, when headers come node-fetch style as array', function(t) {
+  var testThis = {
+    headers: {
+      'Content-Type': ["multipart/form-data;"]
+    }
+  }
+  matchBody.call(testThis, {}, "test");
+  t.end()
+});
+
 tap.test('matchBody uses strict equality for deep comparisons', function(t) {
   var spec = { number: 1 };
   var body = '{"number": "1"}';

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -22,6 +22,36 @@ tap.test('matchBody should not throw, when headers come node-fetch style as arra
   t.end()
 });
 
+tap.test('matchBody should not ignore new line characters from strings when Content-Type contains \'multipart\'', function(t) {
+  var str1 = "something //here is something more \nHello";
+  var str2 = "something //here is something more \nHello";
+  var testThis = {
+    headers: {
+      'Content-Type': "multipart/form-data;"
+    }
+  }
+  var matched = matchBody.call(testThis, function (body) {
+    return body === str1;
+  }, str2);
+  t.true(matched);
+  t.end()
+});
+
+tap.test('matchBody should not ignore new line characters from strings when Content-Type contains \'multipart\' (arrays come node-fetch style as array)', function(t) {
+  var str1 = "something //here is something more \nHello";
+  var str2 = "something //here is something more \nHello";
+  var testThis = {
+    headers: {
+      'Content-Type': ["multipart/form-data;"]
+    }
+  }
+  var matched = matchBody.call(testThis, function (body) {
+    return body === str1;
+  }, str2);
+  t.true(matched);
+  t.end()
+});
+
 tap.test('matchBody uses strict equality for deep comparisons', function(t) {
   var spec = { number: 1 };
   var body = '{"number": "1"}';


### PR DESCRIPTION
Ok, this one took me a while.

`matchBody` [strips line endings](https://github.com/pgte/nock/blob/master/lib/match_body.js#L18) to be consistent across OSs. While this is cool in 99.99% of the cases, it fails when it comes to multipart requests, since mulitpart parsers depend on the line breaks.

This PR disables stripping when `Content-Type` header contains "multipart".

Additionaly a bug is fixed, where matchBody was throwing, when headers came as array (node-fetch style #399, #400).