### PR TITLE
Update #158 fix for request module and strict SSL

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -408,6 +408,12 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
         authorized: true
       });
 
+      // Account for updates to Node.js response interface
+      // cf https://github.com/request/request/pull/1615
+      response.socket = _.extend(response.socket || {}, {
+        authorized: true
+      });
+
       // Evaluate functional headers.
       Object.keys(response.headers).forEach(function (key) {
         var value = response.headers[key];


### PR DESCRIPTION
Commit 48e8be5 added a compatibility fix for users of the request
NPM module and strict SSL cert checking. The request module has
since been updated (see https://github.com/request/request/pull/1615
for more details), and a corresponding change should be made in
nock to ensure compatibility.