### PR TITLE
add ability to match domain using regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For instance, if a module performs HTTP requests to a CouchDB server or makes HT
 - [Install](#install)
 - [Use](#use)
     - [READ THIS](#read-this---about-interceptors)
+    - [Specifying domain](#specifying-domain)
     - [Specifying request body](#specifying-request-body)
     - [Specifying replies](#specifying-replies)
     - [Specifying headers](#specifying-headers)
@@ -93,6 +94,22 @@ Then the test can call the module, and the module will do the HTTP requests.
 When you setup an interceptor for an URL and that interceptor is used, it is removed from the interceptor list.
 This means that you can intercept 2 or more calls to the same URL and return different things on each of them.
 It also means that you must setup one interceptor for each request you are going to have, otherwise nock will throw an error because that URL was not present in the interceptor list.
+
+## Specifying domain
+
+The request domain can be a string or a RegExp
+
+```js
+var scope = nock('http://www.example.com')
+    .get('/resource')
+    .reply(200, 'domain matched');
+```
+
+```js
+var scope = nock(/example\.com/)
+    .get('/resource')
+    .reply(200, 'domain regex matched');
+```
 
 ## Specifying request body
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -248,6 +248,14 @@ function percentEncode(str) {
   });
 }
 
+function matchStringOrRegexp(target, pattern) {
+  if (pattern instanceof RegExp) {
+    return target.toString().match(pattern);
+  } else {
+    return target === pattern;
+  }
+}
+
 exports.normalizeRequestOptions = normalizeRequestOptions;
 exports.isBinaryBuffer = isBinaryBuffer;
 exports.mergeChunks = mergeChunks;
@@ -259,3 +267,4 @@ exports.headersFieldNamesToLowerCase = headersFieldNamesToLowerCase;
 exports.headersFieldsArrayToLowerCase = headersFieldsArrayToLowerCase;
 exports.deleteHeadersField = deleteHeadersField;
 exports.percentEncode = percentEncode;
+exports.matchStringOrRegexp = matchStringOrRegexp;

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -93,7 +93,7 @@ function isOff() {
 
 function add(key, interceptor, scope, scopeOptions, host) {
   if (! allInterceptors.hasOwnProperty(key)) {
-    allInterceptors[key] = [];
+    allInterceptors[key] = { key: key, scopes: [] };
   }
   interceptor.__nock_scope = scope;
 
@@ -104,11 +104,10 @@ function add(key, interceptor, scope, scopeOptions, host) {
   interceptor.__nock_scopeHost = host;
   interceptor.interceptionCounter = 0;
 
-  allInterceptors[key].push(interceptor);
+  allInterceptors[key].scopes.push(interceptor);
 }
 
 function remove(interceptor) {
-
   if (interceptor.__nock_scope.shouldPersist()) {
     return;
   }
@@ -121,7 +120,7 @@ function remove(interceptor) {
   var key          = interceptor._key.split(' '),
       u            = url.parse(key[1]),
       hostKey      = u.protocol + '//' + u.host,
-      interceptors = allInterceptors[hostKey],
+      interceptors = allInterceptors[hostKey] && allInterceptors[hostKey].scopes,
       thisInterceptor;
 
   if (interceptors) {
@@ -140,53 +139,9 @@ function removeAll() {
   allInterceptors = {};
 }
 
-function hasHadInterceptors(options) {
-  var basePath,
-      isBasePathMatched,
-      isScopedMatched;
-
-  debug('hasHadInterceptors', options.host, options.hostname);
-  common.normalizeRequestOptions(options);
-
-  basePath = options.proto + '://' + options.host;
-
-  debug('looking for interceptors for basepath %j', basePath);
-
-  _.each(allInterceptors, function(interceptor, key) {
-    if (key === basePath) {
-      isBasePathMatched = true;
-
-      // false to short circuit the .each
-      return false;
-    }
-
-    _.each(interceptor, function(scope) {
-      var filteringScope = scope.__nock_scopeOptions.filteringScope;
-
-      //  If scope filtering function is defined and returns a truthy value
-      //  then we have to treat this as a match.
-      if (filteringScope && filteringScope(basePath)) {
-        debug('found matching scope interceptor');
-
-        //  Keep the filtered scope (its key) to signal the rest of the module
-        //  that this wasn't an exact but filtered match.
-        scope.__nock_filteredScope = scope.__nock_scopeKey;
-        isScopedMatched = true;
-        //  Break out of _.each for scopes.
-        return false;
-      }
-    });
-
-    //  Returning falsy value here (which will happen if we have found our matching interceptor)
-    //  will break out of _.each for all interceptors.
-    return !isScopedMatched;
-  });
-
-  return (isScopedMatched || isBasePathMatched);
-}
-
 function interceptorsFor(options) {
-  var basePath;
+  var basePath,
+      matchingInterceptor;
 
   common.normalizeRequestOptions(options);
 
@@ -197,9 +152,8 @@ function interceptorsFor(options) {
   debug('filtering interceptors for basepath', basePath);
 
   //  First try to use filteringScope if any of the interceptors has it defined.
-  var matchingInterceptor;
-  _.each(allInterceptors, function(interceptor, key) {
-    _.each(interceptor, function(scope) {
+  _.each(allInterceptors, function(interceptor, k) {
+    _.each(interceptor.scopes, function(scope) {
       var filteringScope = scope.__nock_scopeOptions.filteringScope;
 
       //  If scope filtering function is defined and returns a truthy value
@@ -210,22 +164,24 @@ function interceptorsFor(options) {
         //  Keep the filtered scope (its key) to signal the rest of the module
         //  that this wasn't an exact but filtered match.
         scope.__nock_filteredScope = scope.__nock_scopeKey;
-        matchingInterceptor = interceptor;
+        matchingInterceptor = interceptor.scopes;
         //  Break out of _.each for scopes.
         return false;
       }
     });
+
+    if (!matchingInterceptor && common.matchStringOrRegexp(basePath, interceptor.key)) {
+      matchingInterceptor = interceptor.scopes;
+      // false to short circuit the .each
+      return false;
+    }
 
     //  Returning falsy value here (which will happen if we have found our matching interceptor)
     //  will break out of _.each for all interceptors.
     return !matchingInterceptor;
   });
 
-  if(matchingInterceptor) {
-    return matchingInterceptor;
-  }
-
-  return allInterceptors[basePath] || [];
+  return matchingInterceptor;
 }
 
 function removeInterceptor(options) {
@@ -236,19 +192,19 @@ function removeInterceptor(options) {
   common.normalizeRequestOptions(options);
   baseUrl = proto + '://' + options.host;
 
-  if (allInterceptors[baseUrl] && allInterceptors[baseUrl].length > 0) {
+  if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
     if (options.path) {
       method = options.method && options.method.toUpperCase() || 'GET';
       key = method + ' ' + baseUrl + (options.path || '/');
 
-      for (var i = 0; i < allInterceptors[baseUrl].length; i++) {
-        if (allInterceptors[baseUrl][i]._key === key) {
-          allInterceptors[baseUrl].splice(i, 1);
+      for (var i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
+        if (allInterceptors[baseUrl].scopes[i]._key === key) {
+          allInterceptors[baseUrl].scopes.splice(i, 1);
           break;
         }
       }
     } else {
-      allInterceptors[baseUrl].length = 0;
+      allInterceptors[baseUrl].scopes.length = 0;
     }
 
     return true;
@@ -284,11 +240,10 @@ function overrideClientRequest() {
   function OverriddenClientRequest(options, cb) {
     if (http.OutgoingMessage) http.OutgoingMessage.call(this);
 
-    if (isOn() && hasHadInterceptors(options)) {
+    //  Filter the interceptors per request options.
+    var interceptors = interceptorsFor(options)
 
-      //  Filter the interceptors per request options.
-      var interceptors = interceptorsFor(options);
-
+    if (isOn() && interceptors) {
       debug('using', interceptors.length, 'interceptors');
 
       //  Use filtered interceptors to intercept requests.
@@ -350,7 +305,7 @@ function isActive() {
 
 function isDone() {
   return _.every(allInterceptors, function(interceptors) {
-    return _.every(interceptors, function(interceptor) {
+    return _.every(interceptors.scopes, function(interceptor) {
       return interceptor.__nock_scope.isDone();
     });
   });
@@ -358,8 +313,8 @@ function isDone() {
 
 function pendingMocks() {
   return _.reduce(allInterceptors, function(result, interceptors) {
-    for (var interceptor in interceptors) {
-      result = result.concat(interceptors[interceptor].__nock_scope.pendingMocks());
+    for (var interceptor in interceptors.scopes) {
+      result = result.concat(interceptors.scopes[interceptor].__nock_scope.pendingMocks());
     }
 
     return result;
@@ -377,9 +332,7 @@ function activate() {
   // ----- Overriding http.request and https.request:
 
   common.overrideRequests(function(proto, overriddenRequest, options, callback) {
-
     //  NOTE: overriddenRequest is already bound to its module.
-
     var req,
         res;
 
@@ -388,13 +341,11 @@ function activate() {
     }
     options.proto = proto;
 
-    if (isOn() && hasHadInterceptors(options)) {
+    var interceptors = interceptorsFor(options)
 
-      var interceptors,
-          matches = false,
+    if (isOn() && interceptors) {
+      var matches = false,
           allowUnmocked = false;
-
-      interceptors = interceptorsFor(options);
 
       interceptors.forEach(function(interceptor) {
         if (! allowUnmocked && interceptor.options.allowUnmocked) { allowUnmocked = true; }

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -86,7 +86,6 @@ function setRequestHeaders(req, options, interceptor) {
 }
 
 function RequestOverrider(req, options, interceptors, remove, cb) {
-
   var response;
   if (IncomingMessage) {
     response = new IncomingMessage(new EventEmitter());

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -35,14 +35,19 @@ function startScope(basePath, options) {
       matchHeaders = [],
       logger = debug,
       scopeOptions = options || {},
-      urlParts = url.parse(basePath),
-      port = urlParts.port || ((urlParts.protocol === 'http:') ? 80 : 443),
+      urlParts = {},
       persist = false,
       contentLen = false,
       date = null,
-      basePathname = urlParts.pathname.replace(/\/$/, '');
+      basePathname = '',
+      port;
 
-  basePath = urlParts.protocol + '//' + urlParts.hostname + ':' + port;
+  if (!(basePath instanceof RegExp)) {
+    urlParts = url.parse(basePath);
+    port = urlParts.port || ((urlParts.protocol === 'http:') ? 80 : 443);
+    basePathname = urlParts.pathname.replace(/\/$/, '');
+    basePath = urlParts.protocol + '//' + urlParts.hostname + ':' + port;
+  }
 
   function add(key, interceptor, scope) {
     if (! interceptors.hasOwnProperty(key)) {
@@ -164,23 +169,16 @@ function startScope(basePath, options) {
       return reply.call(this, statusCode, readStream, headers);
     }
 
-    var matchStringOrRegexp = function(target, pattern) {
-      if (pattern instanceof RegExp) {
-        return target.toString().match(pattern);
-      } else {
-        return target === pattern;
-      }
-    };
-
     function match(options, body, hostNameOnly) {
       debug('match %s, body = %s', stringify(options), stringify(body));
       if (hostNameOnly) {
         return options.hostname === urlParts.hostname;
       }
 
-      var method = options.method || 'GET'
+      var method = (options.method || 'GET').toUpperCase()
         , path = options.path
         , matches
+        , matchKey
         , proto = options.proto;
 
       if (transformPathFunction) {
@@ -197,7 +195,7 @@ function startScope(basePath, options) {
         if (_.isFunction(header.value)) {
           return header.value(options.getHeader(header.name));
         }
-        return matchStringOrRegexp(options.getHeader(header.name), header.value);
+        return common.matchStringOrRegexp(options.getHeader(header.name), header.value);
       };
 
       if (!matchHeaders.every(checkHeaders) ||
@@ -233,7 +231,7 @@ function startScope(basePath, options) {
         if (reqHeader && header) {
           if (_.isFunction(reqHeader)) {
             return reqHeader(header);
-          } else if (matchStringOrRegexp(header, reqHeader)) {
+          } else if (common.matchStringOrRegexp(header, reqHeader)) {
             return true;
           }
         }
@@ -262,16 +260,14 @@ function startScope(basePath, options) {
         return false;
       }
 
-      var matchKey = method.toUpperCase() + ' ';
-
       //  If we have a filtered scope then we use it instead reconstructing
       //  the scope from the request options (proto, host and port) as these
       //  two won't necessarily match and we have to remove the scope that was
       //  matched (vs. that was defined).
       if (this.__nock_filteredScope) {
-        matchKey += this.__nock_filteredScope;
+        matchKey = this.__nock_filteredScope;
       } else {
-        matchKey += proto + '://' + options.host;
+        matchKey = proto + '://' + options.host;
         if (
              options.port && options.host.indexOf(':') < 0 &&
              (options.port !== 80 || options.proto !== 'http') &&
@@ -280,14 +276,14 @@ function startScope(basePath, options) {
           matchKey += ":" + options.port;
         }
       }
-      matchKey += path;
 
       // Match query strings when using query()
       var matchQueries = true;
       var queryIndex = -1;
       var queries;
-      if (this.queries && (queryIndex = matchKey.indexOf('?')) !== -1) {
-        queries = matchKey.slice(queryIndex + 1).split('&');
+
+      if (this.queries && (queryIndex = path.indexOf('?')) !== -1) {
+        queries = path.slice(queryIndex + 1).split('&');
         queries = queries.filter(function(str) {
           return str.length > 0;
         });
@@ -314,18 +310,22 @@ function startScope(basePath, options) {
                 break;
               }
 
-              var isMatch = matchStringOrRegexp(query[1], this.queries[ query[0] ]);
+              var isMatch = common.matchStringOrRegexp(query[1], this.queries[ query[0] ]);
               matchQueries = matchQueries && !!isMatch;
             }
           }
           debug('matchQueries: %j', matchQueries);
         }
 
-        // Remove the query string from the matchKey
-        matchKey = matchKey.substr(0, queryIndex);
+        // Remove the query string from the path
+        path = path.substr(0, queryIndex);
       }
 
-      matches = matchKey === this._key && matchQueries;
+      matches = method === this.method &&
+                common.matchStringOrRegexp(matchKey, this.basePath) &&
+                path === this.path  &&
+                matchQueries;
+
 
       // special logger for query()
       if (queryIndex !== -1) {
@@ -346,7 +346,7 @@ function startScope(basePath, options) {
     }
 
     function matchIndependentOfBody(options) {
-      var method = options.method || 'GET'
+      var method = (options.method || 'GET').toUpperCase()
         , path = options.path
         , proto = options.proto;
 
@@ -355,7 +355,7 @@ function startScope(basePath, options) {
       }
 
       var checkHeaders = function(header) {
-        return options.getHeader && matchStringOrRegexp(options.getHeader(header.name), header.value);
+        return options.getHeader && common.matchStringOrRegexp(options.getHeader(header.name), header.value);
       };
 
       if (!matchHeaders.every(checkHeaders) ||
@@ -534,6 +534,9 @@ function startScope(basePath, options) {
 
     var interceptor = {
         _key: key
+      , method: method.toUpperCase()
+      , basePath: basePath
+      , path: basePathname + uri
       , counter: 1
       , _requestBody: requestBody
       //  We use lower-case header field names throughout Nock.

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -150,3 +150,11 @@ tap.test('deleteHeadersField deletes fields with case-insensitive field names', 
 
 });
 
+tap.test('matchStringOrRegexp', function (t) {
+  t.true(common.matchStringOrRegexp('to match', 'to match'), 'true if pattern is string and target matches');
+  t.false(common.matchStringOrRegexp('to match', 'not to match'), 'false if pattern is string and target doesn\'t match');
+
+  t.ok(common.matchStringOrRegexp('to match', /match/), 'match if pattern is regex and target matches');
+  t.false(common.matchStringOrRegexp('to match', /not/), 'false if pattern is regex and target doesn\'t match');
+  t.end();
+});

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -3880,6 +3880,20 @@ test('hyperquest works', function(t) {
   });
 });
 
+test('match domain using regexp', function (t) {
+  var scope = nock(/regexexample\.com/)
+    .get('/resources')
+    .reply(200, 'Match regex');
+
+  mikealRequest.get('http://www.regexexample.com/resources', function(err, res, body) {
+    t.type(err, 'null');
+    t.equal(res.statusCode, 200);
+    t.equal(body, 'Match regex');
+
+    t.end();
+  });
+});
+
 test('remove interceptor for GET resource', function(t) {
   var scope = nock('http://example.org')
     .get('/somepath')


### PR DESCRIPTION
Related to https://github.com/pgte/nock/issues/347, but I did first for `domain`. 

If you like this line, I can implement for the `path` as well (Now that I break the matches by `URL part` will be much easier to add `regex match` at `paths`).

Just let me know and I can implement in this pull request or in a new one after the merge.

**Notes:**
- I removed the `hasHadInterceptors` because it has almost the same responsibility of `interceptorsFor`, so I've adapted to have a single method to return the proper interceptor;
- I tried to avoid changing the `allInterceptors` structure, but couldn't find any easy way to store the regex as the key of the object;

**Example:**

```js
var scope = nock(/regexexample\.com/)
    .get('/resources')
    .reply(200, 'Match regex');

  mikealRequest.get('http://www.regexexample.com/resources', function(err, res, body) {
    t.type(err, 'null');
    t.equal(res.statusCode, 200);
    t.equal(body, 'Match regex');

    t.end();
  });
```