### PR TITLE
Fixed issue with header function evaluation + added 2 tests

### DIFF
--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -292,8 +292,10 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       return;
     }
     response.statusCode = Number(interceptor.statusCode) || 200;
-    response.headers = interceptor.headers || {};
-    response.rawHeaders = interceptor.rawHeaders || [];
+
+    // Clone headers/rawHeaders to not override them when evaluating later
+    response.headers = _.extend({}, interceptor.headers);
+    response.rawHeaders = (interceptor.rawHeaders || []).slice();
     debug('response.rawHeaders:', response.rawHeaders);
 
 
@@ -439,18 +441,20 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
       });
 
       // Evaluate functional headers.
+      var evaluatedHeaders = {}
       Object.keys(response.headers).forEach(function (key) {
         var value = response.headers[key];
 
         if (typeof value === "function") {
-          response.headers[key] = value(req, response, responseBody);
+          response.headers[key] = evaluatedHeaders[key] = value(req, response, responseBody);
         }
       });
 
       for(var rawHeaderIndex = 0 ; rawHeaderIndex < response.rawHeaders.length ; rawHeaderIndex += 2) {
+        var key = response.rawHeaders[rawHeaderIndex];
         var value = response.rawHeaders[rawHeaderIndex + 1];
         if (typeof value === "function") {
-          response.rawHeaders[rawHeaderIndex + 1] = value(req, response, responseBody);
+          response.rawHeaders[rawHeaderIndex + 1] = evaluatedHeaders[key];
         }
       }
 


### PR DESCRIPTION
Fixes #454 

1. Reply header functions were evaluated twice per request.
2. Reply header functions were overridden by evaluated values.

After fix each header function is evaluated only once per request.
After fix each header function is evaluated on each and every request separately.