### PR TITLE
dont execute `replace` on a non-string

### DIFF
--- a/lib/match_body.js
+++ b/lib/match_body.js
@@ -21,7 +21,7 @@ function matchBody(spec, body) {
 
   //strip line endings from both so that we get a match no matter what OS we are running on
   //if Content-Type does not contains 'multipart'
-  if (!isMultipart) {
+  if (!isMultipart && typeof body === "string") {
     body = body.replace(/\r?\n|\r/g, '');
   }
 


### PR DESCRIPTION
recorded bodies can be an object (json).  dont try to use a string function on them.