### PR TITLE
Optimize for large number of interceptors

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -348,9 +348,12 @@ function activate() {
       var matches = false,
           allowUnmocked = false;
 
-      interceptors.forEach(function(interceptor) {
-        if (! allowUnmocked && interceptor.options.allowUnmocked) { allowUnmocked = true; }
-        if (interceptor.matchIndependentOfBody(options)) { matches = true; }
+      matches = !! _.find(interceptors, function(interceptor) {
+        return interceptor.matchIndependentOfBody(options);
+      });
+        
+      allowUnmocked = !! _.find(interceptors, function(interceptor) {
+        return interceptor.options.allowUnmocked;
       });
 
       if (! matches && allowUnmocked) {

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -185,7 +185,10 @@ Interceptor.prototype.reqheaderMatches = function reqheaderMatches(options, key)
 };
 
 Interceptor.prototype.match = function match(options, body, hostNameOnly) {
-    debug('match %s, body = %s', stringify(options), stringify(body));
+    if (debug.enabled) {
+        debug('match %s, body = %s', stringify(options), stringify(body));
+    }
+
     if (hostNameOnly) {
         return options.hostname === this.scope.urlParts.hostname;
     }

--- a/lib/interceptor.js
+++ b/lib/interceptor.js
@@ -45,11 +45,7 @@ function Interceptor(scope, uri, method, requestBody, interceptorOptions) {
 Interceptor.prototype.replyWithError = function replyWithError(errorMessage) {
     this.errorMessage = errorMessage;
 
-    for (var opt in this.scope.scopeOptions) {
-        if (_.isUndefined(this.options[opt])) {
-            this.options[opt] = this.scope.scopeOptions[opt];
-        }
-    }
+    _.defaults(this.options, this.scope.scopeOptions);
 
     this.scope.add(this._key, this, this.scope, this.scopeOptions);
     return this.scope;
@@ -66,11 +62,7 @@ Interceptor.prototype.reply = function reply(statusCode, body, headers) {
     //  We use lower-case headers throughout Nock.
     headers = common.headersFieldNamesToLowerCase(headers);
 
-    for (var opt in this.scope.scopeOptions) {
-        if (_.isUndefined(this.options[opt])) {
-            this.options[opt] = this.scope.scopeOptions[opt];
-        }
-    }
+    _.defaults(this.options, this.scope.scopeOptions);
 
     if (this.scope._defaultReplyHeaders) {
         headers = headers || {};

--- a/lib/request_overrider.js
+++ b/lib/request_overrider.js
@@ -90,7 +90,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
   }
 
   var requestBodyBuffers = [],
-      originalInterceptors = interceptors,
       aborted,
       emitError,
       end,
@@ -231,21 +230,23 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     /// because bad behaving agents like superagent
     /// like to change request.path in mid-flight.
     options.path = req.path;
-    interceptors = interceptors.filter(function(interceptor) {
+
+    interceptors.forEach(function(interceptor) {
       //  For correct matching we need to have correct request headers - if these were specified.
       setRequestHeaders(req, options, interceptor);
-
+    });
+      
+    interceptor = _.find(interceptors, function(interceptor) {
       return interceptor.match(options, requestBody);
     });
 
-    if (interceptors.length < 1) {
+    if (!interceptor) {
       globalEmitter.emit('no match', req, options, requestBody);
       // Try to find a hostname match
-      interceptors = originalInterceptors.filter(function(interceptor) {
+      interceptor = _.find(interceptors, function(interceptor) {
         return interceptor.match(options, requestBody, true);
       });
-      if (interceptors.length && req instanceof ClientRequest) {
-        interceptor = interceptors[0];
+      if (interceptor && req instanceof ClientRequest) {
         if (interceptor.options.allowUnmocked) {
           var newReq = new ClientRequest(options, cb);
           propagate(newReq, req);
@@ -262,8 +263,6 @@ function RequestOverrider(req, options, interceptors, remove, cb) {
     }
 
     debug('interceptor identified, starting mocking');
-
-    interceptor = interceptors.shift();
 
     //  We again set request headers, now for our matched interceptor.
     setRequestHeaders(req, options, interceptor);

--- a/tests/test_intercept.js
+++ b/tests/test_intercept.js
@@ -2540,6 +2540,23 @@ test('allow unmocked post with json data', function(t) {
   });
 });
 
+test('allow unmocked passthrough with mismatched bodies', function(t) {
+  var scope = nock('http://httpbin.org', { allowUnmocked: true }).
+    post("/post", {some: 'otherdata'}).
+    reply(404, "Hey!");
+
+  var options = {
+    method: 'POST',
+    uri: 'http://httpbin.org/post',
+    json: { some: 'data' }
+  };
+
+  mikealRequest(options, function(err, resp, body) {
+    t.equal(200, resp.statusCode)
+    t.end();
+  });
+});
+
 test('allow unordered body with json encoding', function(t) {
   var scope =
   nock('http://wtfjs.org')


### PR DESCRIPTION
When a large number of requests are nocked and the interceptor list is large, the amount of time spent processing request is larger than it needs to be. I've pushed a couple of fixes that optimize nock for the scenario with a large number of interceptors.  

If there are any issues I'm happy to address them. I've run with these changes in my own project testing and it works faster for me.