### PR TITLE
Call `nock.removeInterceptor()` with interceptor instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ nock.recorder.rec({
 ```
 
 ## .removeInterceptor()
-This allows removing a specific interceptor for a url. It's useful when there's a list of common interceptors but one test requires one of them to behave differently.
+This allows removing a specific interceptor. This can be either an interceptor instance or options for a url. It's useful when there's a list of common interceptors shared between tests, where an individual test requires one of the shared interceptors to behave differently.
 
 Examples:
 ```js
@@ -1113,6 +1113,12 @@ nock.removeInterceptor({
   method: 'POST'
   proto : 'https'
 });
+```
+
+```js
+var interceptor = nock('http://example.org')
+  .get('somePath');
+nock.removeInterceptor(interceptor);
 ```
 
 # Events

--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -8,6 +8,7 @@ var RequestOverrider = require('./request_overrider'),
     common           = require('./common'),
     url              = require('url'),
     inherits         = require('util').inherits,
+    Interceptor      = require('./interceptor'),
     http             = require('http'),
     parse            = require('url').parse,
     _                = require('lodash'),
@@ -187,17 +188,20 @@ function interceptorsFor(options) {
 
 function removeInterceptor(options) {
   var baseUrl, key, method, proto;
+  if (options instanceof Interceptor) {
+    baseUrl = options.basePath;
+    key = options._key;
+  } else {
+    proto = options.proto ? options.proto : 'http';
 
-  proto = options.proto ? options.proto : 'http';
-
-  common.normalizeRequestOptions(options);
-  baseUrl = proto + '://' + options.host;
+    common.normalizeRequestOptions(options);
+    baseUrl = proto + '://' + options.host;
+    method = options.method && options.method.toUpperCase() || 'GET';
+    key = method + ' ' + baseUrl + (options.path || '/');
+  }
 
   if (allInterceptors[baseUrl] && allInterceptors[baseUrl].scopes.length > 0) {
-    if (options.path) {
-      method = options.method && options.method.toUpperCase() || 'GET';
-      key = method + ' ' + baseUrl + (options.path || '/');
-
+    if (key) {
       for (var i = 0; i < allInterceptors[baseUrl].scopes.length; i++) {
         if (allInterceptors[baseUrl].scopes[i]._key === key) {
           allInterceptors[baseUrl].scopes.splice(i, 1);
@@ -351,7 +355,7 @@ function activate() {
       matches = !! _.find(interceptors, function(interceptor) {
         return interceptor.matchIndependentOfBody(options);
       });
-        
+
       allowUnmocked = !! _.find(interceptors, function(interceptor) {
         return interceptor.options.allowUnmocked;
       });


### PR DESCRIPTION
Previously `nock.removeInterceptor()` only took an options object. This was inconvenient if the client didn't wish to expose urls directly in their tests.

`removeInterceptor()` now takes both the original options object, or an alternative instance of `Interceptor` and uses the instance variables `baseUrl` and `_key` to filter for removal.

Added 3 test cases to cover http, https and regex path matching.

I'm not 100% sure this PR covers all cases of `Interceptor` object's `baseUrl` variable being consistent with the keys of `allInterceptors`, was hoping you could clarify that.

**Resolves #447**